### PR TITLE
WIP: Abstract algorithmic interface for iterative orthogonalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,27 @@ This package provides iterative algorithms for solving linear systems, eigensyst
 - [Issue #1](https://github.com/JuliaLang/IterativeSolvers.jl/issues/1) documents the implementation roadmap.
 - The interfaces between the various algorithms are still in flux, but aim to be consistent.
 
+## Orthogonalization methods for `qrfact!`
+
+This package provides new methods for `qrfact!` and uses an abstract algorithm interface that inherits from `Base.Algorithm`. The method signature looks like
+
+    qrfact!(A, alg(params...))
+
+Valid values for `alg` are:
+
+- `cgs`: classical Gram-Schmidt
+- `cmgs`: columnwise modified Gram-Schmidt
+
+### Normalization algorithms
+
+    normalize!(v, alg)
+
+Valid values for `alg` are:
+
+- `norm_none`: no normalization
+- `norm_naive`: naïve normalization using `norm()` (default)
+- `norm_pythag`: Pythagorean normalization ([doi:10.1007/s00211-006-0042-1](http://dx.doi.org/10.1007/s00211-006-0042-1)) - takes as parameter an `AbstractVector` which represent a column of previously computed `R` factors.
+
 ## Consistent interface
 
 ### Nomenclature

--- a/README.md
+++ b/README.md
@@ -16,26 +16,33 @@ This package provides iterative algorithms for solving linear systems, eigensyst
 - [Issue #1](https://github.com/JuliaLang/IterativeSolvers.jl/issues/1) documents the implementation roadmap.
 - The interfaces between the various algorithms are still in flux, but aim to be consistent.
 
-## Orthogonalization methods for `qrfact!`
+## Orthogonalization algorithms
 
 This package provides new methods for `qrfact!` and uses an abstract algorithm interface that inherits from `Base.Algorithm`. The method signature looks like
 
     qrfact!(A, alg(params...))
 
-Valid values for `alg` are:
+`alg` is a type of subtype `OrthogonalizationAlg` (unexported). Valid types are:
 
 - `cgs`: classical Gram-Schmidt
 - `cmgs`: columnwise modified Gram-Schmidt
 
-### Normalization algorithms
+Each `OrthogonalizationAlg` wraps the following parameters
 
-    normalize!(v, alg)
+- `n`: the number of orthogonal vectors to compute. If `nothing`, computes all of them.
+- `normalize`: choice of normalization algorithm. Valid types are:
+  - `norm_none`: no normalization
+  - `norm_naive`: naïve normalization using `norm()` (default)
+  - `norm_pythag`: Pythagorean normalization ([doi:10.1007/s00211-006-0042-1](http://dx.doi.org/10.1007/s00211-006-0042-1))
 
-Valid values for `alg` are:
-
-- `norm_none`: no normalization
-- `norm_naive`: naïve normalization using `norm()` (default)
-- `norm_pythag`: Pythagorean normalization ([doi:10.1007/s00211-006-0042-1](http://dx.doi.org/10.1007/s00211-006-0042-1)) - takes as parameter an `AbstractVector` which represent a column of previously computed `R` factors.
+- `reorth`: choice of reorthogonalization algorithm. This is specified as an (unexported) `ReorthogonalizationAlg` type wrapping the following parameters:
+  - `criterion`: specifies when reorthogonalization is carried out. Valid values are:
+    - `never`: never reorthogonalize (default)
+    - `always`: always reorthgonalize
+    - `rutishauser(K)`: use Rutishauser's criterion for adaptive reorthogonalization with threshold `K` (default `K = 10.0`, which is Rutishauser's original choice, but `K = √2` is also a popular choice).
+    - `giraudlangou(K)`: use Giraud and Langou's criterion for adaptive reorthogonalization with threshold `K`. 
+  - `isforward`: whether to reorthogonalize from first to last vector (`true`, default) or not (`false`)
+  - `maxiter`: the maximum number of reorthogonalization passes to carry out. (Default: 1)
 
 ## Consistent interface
 

--- a/src/IterativeSolvers.jl
+++ b/src/IterativeSolvers.jl
@@ -2,6 +2,9 @@ module IterativeSolvers
 include("common.jl")
 include("krylov.jl")
 
+#Orthogonalization routines
+include("qr.jl")
+
 #Linear solvers
 include("stationary.jl")
 include("cg.jl")

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -67,19 +67,34 @@ function qrfact!(Q, parameters::ClassicalGramSchmidtAlg)
     ncols = parameters.n===nothing ? size(Q, 2) : parameters.n
     R=zeros(ncols, ncols)
     for k=1:ncols
-        parameters.normalize===norm_pythag && (s=norm(Q[:,k]))
+        s=norm(Q[:,k])
         for i=1:k-1
             R[i,k] = Q[:,i]⋅Q[:,k]
         end
         for i=1:k-1
             Q[:,k]-= R[i,k]*Q[:,i]
         end
-        Q[:,k], R[k,k] = parameters.normalize===norm_pythag ?
-            normalize!(Q[:,k], s, R[1:k-1,k], norm_pythag) :
-            normalize!(Q[:,k], parameters.normalize)
+        Q[:,k], R[k,k] = normalize!(Q[:,k], parameters.normalize)
     end
     QRPair(Q, Triangular(R, :U))
 end
+
+function qrfact!(Q, parameters::ClassicalGramSchmidtAlg{norm_pythag})
+    ncols = parameters.n===nothing ? size(Q, 2) : parameters.n
+    R=zeros(ncols, ncols)
+    for k=1:ncols
+        s=norm(Q[:,k])
+        for i=1:k-1
+            R[i,k] = Q[:,i]⋅Q[:,k]
+        end
+        for i=1:k-1
+            Q[:,k]-= R[i,k]*Q[:,i]
+        end
+        Q[:,k], R[k,k] = normalize!(Q[:,k], s, R[1:k-1,k], norm_pythag)
+    end
+    QRPair(Q, Triangular(R, :U))
+end
+
 #Support qrfact!(A, cgs) call
 qrfact!(A, ::Type{ClassicalGramSchmidtAlg}) = qrfact!(A, cgs()) 
 
@@ -99,17 +114,29 @@ function qrfact!(Q, parameters::ColumnwiseModifiedGramSchmidtAlg)
     ncols = parameters.n===nothing ? size(Q, 2) : parameters.n
     R=zeros(ncols, ncols)
     for k=1:ncols
-        parameters.normalize===norm_pythag && (s=norm(Q[:,k]))
     	for i=1:k-1
     	    R[i,k] = Q[:,i]⋅Q[:, k]
     	    Q[:, k]-= R[i, k]*Q[:, i]
     	end
-        Q[:,k], R[k,k] = parameters.normalize===norm_pythag ?
-            normalize!(Q[:,k], s, R[1:k-1,k], norm_pythag) :
-            normalize!(Q[:,k], parameters.normalize)
+        Q[:,k], R[k,k] = normalize!(Q[:,k], parameters.normalize)
     end
     QRPair(Q, Triangular(R, :U))
 end
+
+function qrfact!(Q, parameters::ColumnwiseModifiedGramSchmidtAlg{norm_pythag})
+    ncols = parameters.n===nothing ? size(Q, 2) : parameters.n
+    R=zeros(ncols, ncols)
+    for k=1:ncols
+        s=norm(Q[:,k])
+        for i=1:k-1
+            R[i,k] = Q[:,i]⋅Q[:, k]
+            Q[:, k]-= R[i, k]*Q[:, i]
+        end
+        Q[:,k], R[k,k] = normalize!(Q[:,k], s, R[1:k-1,k], norm_pythag)
+    end
+    QRPair(Q, Triangular(R, :U))
+end
+
 #Support qrfact!(A, cmgs) call
 qrfact!(A, ::Type{ColumnwiseModifiedGramSchmidtAlg}) = qrfact!(A, cmgs()) 
 

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -1,7 +1,7 @@
 #Iterative algorithms for orthogonalization
 
 import Base: Algorithm, qrfact!
-export cgs
+export cgs, cmgs
 
 #Type to store the output
 immutable QRPair{T}
@@ -24,7 +24,7 @@ typealias cgs ClassicalGramSchmidtAlg
 cgs() = cgs(nothing)
 
 function qrfact!(Q, parameters::ClassicalGramSchmidtAlg)
-    ncols = parameters.n===nothing ? size(A, 2) : parameters.n
+    ncols = parameters.n===nothing ? size(Q, 2) : parameters.n
     R=zeros(ncols, ncols)
     for k=1:ncols
         for i=1:k-1
@@ -41,5 +41,29 @@ end
 #Support qrfact!(A, cgs) call
 qrfact!(A, ::Type{ClassicalGramSchmidtAlg}) = qrfact!(A, cgs()) 
 
+#Columnwise modified Gram-Schmidt
+
+immutable ColumnwiseModifiedGramSchmidtAlg <: OrthogonalizationAlg
+    n::Union(Int, Nothing) #Number of Gram-Schmidt columns to compute
+end
+
+typealias cmgs ColumnwiseModifiedGramSchmidtAlg
+cmgs() = cmgs(nothing)
+
+function qrfact!(Q, parameters::ColumnwiseModifiedGramSchmidtAlg)
+    ncols = parameters.n===nothing ? size(Q, 2) : parameters.n
+    R=zeros(ncols, ncols)
+    for k=1:ncols
+	for i=1:k-1
+	    R[i,k] = Q[:,i]⋅Q[:, k]
+	    Q[:, k]-= R[i, k]*Q[:, i]
+	end
+	R[k,k] = norm(Q[:,k])
+	Q[:,k]/= R[k,k]
+    end
+    QRPair(Q, Triangular(R, :U))
+end
+#Support qrfact!(A, cmgs) call
+qrfact!(A, ::Type{ColumnwiseModifiedGramSchmidtAlg}) = qrfact!(A, cmgs()) 
 
 include("../test/qr.jl")

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -1,0 +1,45 @@
+#Iterative algorithms for orthogonalization
+
+import Base: Algorithm, qrfact!
+export cgs
+
+#Type to store the output
+immutable QRPair{T}
+    Q::Matrix{T}
+    R::Triangular{T, Matrix{T}, :U}
+    ϵ::Float64 #Residual
+end
+QRPair(Q, R, ϵ::Real=0) = size(Q,2)==size(R,1)==size(R,2) ? QRPair(Q, R, float64(ϵ)) : throw(DimensionMismatch(""))
+
+#The algorithm type hierarchy
+abstract OrthogonalizationAlg <: Algorithm
+
+#Classical Gram-Schmidt
+
+immutable ClassicalGramSchmidtAlg <: OrthogonalizationAlg
+    n::Union(Int, Nothing) #Number of Gram-Schmidt columns to compute
+end
+
+typealias cgs ClassicalGramSchmidtAlg
+cgs() = cgs(nothing)
+
+function qrfact!(Q, parameters::ClassicalGramSchmidtAlg)
+    ncols = parameters.n===nothing ? size(A, 2) : parameters.n
+    R=zeros(ncols, ncols)
+    for k=1:ncols
+        for i=1:k-1
+            R[i,k] = Q[:,i]⋅Q[:,k]
+        end
+        for i=1:k-1
+            Q[:,k]-= R[i,k]*Q[:,i]
+        end
+        R[k,k] = norm(Q[:,k])
+        Q[:,k]/= R[k,k]
+    end
+    QRPair(Q, Triangular(R, :U))
+end
+#Support qrfact!(A, cgs) call
+qrfact!(A, ::Type{ClassicalGramSchmidtAlg}) = qrfact!(A, cgs()) 
+
+
+include("../test/qr.jl")

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -2,6 +2,7 @@
 
 import Base: Algorithm, qrfact!
 export norm_none, norm_naive, norm_pythag,
+       ReorthogonalizationAlg, never, always, rutishauser, giraudlangou,
        cgs, cmgs
 
 #########################
@@ -49,6 +50,7 @@ immutable always <: Criterion end
 immutable rutishauser{T<:Real} <: Criterion
     K :: T
 end
+rutishauser()=rutishauser(10.0) #Rutishauser's original choice
 
 immutable giraudlangou{T<:Real} <: Criterion
     K :: T
@@ -61,8 +63,8 @@ immutable ReorthogonalizationAlg{C<:Criterion} <: Algorithm
 end
 
 ReorthogonalizationAlg(criterion::Criterion,
-        isforward::Bool=true, maxiter::Integer=1) = (@show 1;
-    ReorthogonalizationAlg{C}(criterion, isforward, int(maxiter)))
+        isforward::Bool=true, maxiter::Integer=1) = 
+    ReorthogonalizationAlg{C}(criterion, isforward, int(maxiter))
 #Support calls like ReorthogonalizationAlg(never) and ReorthogonalizationAlg(always)
 ReorthogonalizationAlg{C<:Criterion}(criterion::Type{C}) = 
     ReorthogonalizationAlg(criterion())
@@ -71,21 +73,31 @@ ReorthogonalizationAlg()=ReorthogonalizationAlg(never)
 #Check if reorthogonalization is necessary and do it if it is
 function reorthogonalize!(alg::ReorthogonalizationAlg, Q, R, k::Int)
     for iter = 1:alg.maxiter
-        #Check if criterion is triggered
-        do_reorth = !isa(alg.criterion, never) || isa(alg.criterion, always)
-        if isa(alg.criterion, rutishauser)
-            do_reorth = R[k,k] > alg.criterion.K*norm(Q[:,k])
-        elseif isa(alg.criterion, giraudlangou)
-            do_reorth = norm(R[1:k-1,k], 1) > criterion.K*norm(Q[:,k])
-        end
-        do_reorth || continue
-
-        #Reorthogonalize
-        for i = (alg.isforward ? (1:k) : (k:-1:1))
-            Q[:, k]-= R[i, k]*Q[:, i]
+        do_reorth(alg, Q, R, k) || continue
+        for i = (alg.isforward ? (1:k-1) : (k-1:-1:1))
+            d = Q[:,k]⋅Q[:,i]
+            Q[:,k]-=d*Q[:,i]
+            R[i,k]+=d
         end
     end
     nothing
+end
+
+function do_reorth(alg::ReorthogonalizationAlg, Q, R, k::Int)
+    if isa(alg.criterion, never)
+        return false
+    elseif isa(alg.criterion, always)
+        return true
+    elseif isa(alg.criterion, rutishauser)
+        #XXX This assumes that R[k,k] contains the original norm(Q[:,k])
+        #    before orthogonalization!! Need to change rutishauser to
+        #    stash this constant
+        return R[k,k] > alg.criterion.K*norm(Q[:,k])
+    elseif isa(alg.criterion, giraudlangou)
+        return norm(R[1:k-1,k], 1) > alg.criterion.K*norm(Q[:,k])
+    else
+        throw(ArgumentError("Unknown ReorthogonalizationAlg: $alg"))
+    end
 end
 
 ################################
@@ -112,15 +124,15 @@ immutable ClassicalGramSchmidtAlg{Norm<:NormalizationAlg, Reorth<:Reorthogonaliz
 end
 
 typealias cgs ClassicalGramSchmidtAlg
-cgs{Norm<:NormalizationAlg}(n, norm::Type{Norm},
-    reorth::ReorthogonalizationAlg=ReorthogonalizationAlg()) = cgs(n, norm, reorth)
+cgs{Norm<:NormalizationAlg,Reorth<:ReorthogonalizationAlg}(n, norm::Type{Norm},
+    reorth::Reorth=ReorthogonalizationAlg()) = cgs(n, norm, reorth)
 cgs(n::Nothing) = cgs(n, NORM_DEFAULT)
 cgs(n::Integer) = cgs(int(n), NORM_DEFAULT)
 cgs() = cgs(nothing)
 
 function qrfact!(Q, parameters::ClassicalGramSchmidtAlg)
     ncols = parameters.n===nothing ? size(Q, 2) : parameters.n
-    R=zeros(ncols, ncols)
+    R=zeros(eltype(Q), ncols, ncols)
     for k=1:ncols
         s=norm(Q[:,k])
         for i=1:k-1
@@ -137,7 +149,7 @@ end
 
 function qrfact!(Q, parameters::ClassicalGramSchmidtAlg{norm_pythag})
     ncols = parameters.n===nothing ? size(Q, 2) : parameters.n
-    R=zeros(ncols, ncols)
+    R=zeros(eltype(Q), ncols, ncols)
     for k=1:ncols
         s=norm(Q[:,k])
         for i=1:k-1
@@ -172,7 +184,7 @@ cmgs() = cmgs(nothing)
 
 function qrfact!(Q, parameters::ColumnwiseModifiedGramSchmidtAlg)
     ncols = parameters.n===nothing ? size(Q, 2) : parameters.n
-    R=zeros(ncols, ncols)
+    R=zeros(eltype(Q), ncols, ncols)
     for k=1:ncols
     	for i=1:k-1
     	    R[i,k] = Q[:,i]⋅Q[:,k]
@@ -186,7 +198,7 @@ end
 
 function qrfact!(Q, parameters::ColumnwiseModifiedGramSchmidtAlg{norm_pythag})
     ncols = parameters.n===nothing ? size(Q, 2) : parameters.n
-    R=zeros(ncols, ncols)
+    R=zeros(eltype(Q), ncols, ncols)
     for k=1:ncols
         s=norm(Q[:,k])
         for i=1:k-1

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -105,10 +105,18 @@ end
 ################################
 
 #Type to store the output
-immutable QRPair{T}
-    Q::Matrix{T}
-    R::Triangular{T, Matrix{T}, :U}
-    ϵ::Float64 #Residual
+if v"0.2" <= VERSION <= v"0.3-"
+    immutable QRPair{T}
+        Q::Matrix{T}
+        R::Triangular{T}
+        ϵ::Float64 #Residual
+    end
+else
+    immutable QRPair{T}
+        Q::Matrix{T}
+        R::Triangular{T, Matrix{T}, :U}
+        ϵ::Float64 #Residual
+    end
 end
 QRPair(Q, R, ϵ::Real=0) = size(Q,2)==size(R,1)==size(R,2) ? QRPair(Q, R, float64(ϵ)) : throw(DimensionMismatch(""))
 

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -3,6 +3,49 @@
 import Base: Algorithm, qrfact!
 export cgs, cmgs
 
+#########################
+# Normalization methods #
+#########################
+
+abstract NormalizationAlg <: Algorithm
+normalize!(v) = normalize!(v, NORM_DEFAULT)
+
+#No normalization
+immutable norm_none <: NormalizationAlg end
+normalize!(v::AbstractVector, parameters::norm_none) = v, 1.0
+
+#Naive normalization
+immutable norm_naive <: NormalizationAlg end
+function normalize!(v::AbstractVector, parameters::norm_naive)
+    nrm = norm(v)
+    v/nrm, nrm
+end
+
+#Pythagorean normalization
+#Ref: doi:10.1007/s00211-006-0042-1
+immutable norm_pythag <: NormalizationAlg
+    u::AbstractVector
+end
+
+const NORM_DEFAULT = norm_naive() #Default is naive normalization
+
+#This looks a little weird, but if you don't call the Pythagorean algorithm with
+#any previously computed data, then the algorithm reduces to the naive one.
+#So the default constructor will simply reassign the normalization algorithm to
+#the naive one.
+norm_pythag() = norm_naive()
+
+function normalize!(v::AbstractVector, parameters::norm_pythag)
+    s = norm(v)
+    p = norm(parameters.u)
+    nrm = √(s-p)*√(s+p)
+    v/nrm, nrm
+end
+
+################################
+# Orthogonalization algorithms #
+################################
+
 #Type to store the output
 immutable QRPair{T}
     Q::Matrix{T}
@@ -18,9 +61,12 @@ abstract OrthogonalizationAlg <: Algorithm
 
 immutable ClassicalGramSchmidtAlg <: OrthogonalizationAlg
     n::Union(Int, Nothing) #Number of Gram-Schmidt columns to compute
+    normalize::NormalizationAlg
 end
 
 typealias cgs ClassicalGramSchmidtAlg
+cgs(n::Nothing) = cgs(n, NORM_DEFAULT)
+cgs(n::Integer) = cgs(int(n), NORM_DEFAULT)
 cgs() = cgs(nothing)
 
 function qrfact!(Q, parameters::ClassicalGramSchmidtAlg)
@@ -33,8 +79,7 @@ function qrfact!(Q, parameters::ClassicalGramSchmidtAlg)
         for i=1:k-1
             Q[:,k]-= R[i,k]*Q[:,i]
         end
-        R[k,k] = norm(Q[:,k])
-        Q[:,k]/= R[k,k]
+        Q[:,k], R[k,k] = normalize!(Q[:,k], parameters.normalize)
     end
     QRPair(Q, Triangular(R, :U))
 end
@@ -45,59 +90,27 @@ qrfact!(A, ::Type{ClassicalGramSchmidtAlg}) = qrfact!(A, cgs())
 
 immutable ColumnwiseModifiedGramSchmidtAlg <: OrthogonalizationAlg
     n::Union(Int, Nothing) #Number of Gram-Schmidt columns to compute
+    normalize::NormalizationAlg
 end
 
 typealias cmgs ColumnwiseModifiedGramSchmidtAlg
+cmgs(n::Nothing) = cmgs(n, NORM_DEFAULT)
+cmgs(n::Integer) = cmgs(int(n), NORM_DEFAULT)
 cmgs() = cmgs(nothing)
 
 function qrfact!(Q, parameters::ColumnwiseModifiedGramSchmidtAlg)
     ncols = parameters.n===nothing ? size(Q, 2) : parameters.n
     R=zeros(ncols, ncols)
     for k=1:ncols
-	for i=1:k-1
-	    R[i,k] = Q[:,i]⋅Q[:, k]
-	    Q[:, k]-= R[i, k]*Q[:, i]
-	end
-	R[k,k] = norm(Q[:,k])
-	Q[:,k]/= R[k,k]
+    	for i=1:k-1
+    	    R[i,k] = Q[:,i]⋅Q[:, k]
+    	    Q[:, k]-= R[i, k]*Q[:, i]
+    	end
+        Q[:,k], R[k,k] = normalize!(Q[:,k], parameters.normalize)
     end
     QRPair(Q, Triangular(R, :U))
 end
 #Support qrfact!(A, cmgs) call
 qrfact!(A, ::Type{ColumnwiseModifiedGramSchmidtAlg}) = qrfact!(A, cmgs()) 
-
-#Normalization methods
-abstract NormalizationAlg <: Algorithm
-normalize!(v) = normalize!(v, norm_naive) #Default is naive normalization
-
-#No normalization
-immutable norm_none <: NormalizationAlg end
-normalize!(v::AbstractVector, ::Type{norm_none}) = v, 1.0
-
-#Naive normalization
-immutable norm_naive <: NormalizationAlg end
-function normalize!(v::AbstractVector, ::Type{norm_naive})
-    nrm = norm(v)
-    v/nrm, nrm
-end
-
-#Pythagorean normalization
-#Ref: doi:10.1007/s00211-006-0042-1
-immutable norm_pythag <: NormalizationAlg
-    u::AbstractVector
-end
-
-#This looks a little weird, but if you don't call the Pythagorean algorithm with
-#any previously computed data, then the algorithm reduces to the naive one.
-#So the default constructor will simply reassign the normalization algorithm to
-#the naive one.
-norm_pythag() = norm_naive
-
-function normalize!(v::AbstractVector, parameters::norm_pythag)
-    s = norm(v)
-    p = norm(parameters.u)
-    nrm = √(s-p)*√(s+p)
-    v/nrm, nrm
-end
 
 include("../test/qr.jl")

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -20,7 +20,7 @@ normalize!(v::AbstractVector, ::Type{norm_none}) = v, 1.0
 immutable norm_naive <: NormalizationAlg end
 function normalize!(v::AbstractVector, ::Type{norm_naive})
     nrm = norm(v)
-    v/nrm, nrm
+    scale!(v, one(nrm)/nrm), nrm
 end
 
 #Pythagorean normalization
@@ -29,7 +29,7 @@ immutable norm_pythag <: NormalizationAlg end
 
 function normalize!{T}(v::AbstractVector{T}, s::Real, p::Real, ::Type{norm_pythag})
     nrm = √(s-p)*√(s+p)
-    v/nrm, nrm
+    scale!(v, one(nrm)/nrm), nrm
 end
 
 normalize!{T}(v::AbstractVector{T}, s::Real, u::AbstractVector{T}, ::Type{norm_pythag}) =

--- a/test/qr.jl
+++ b/test/qr.jl
@@ -1,13 +1,15 @@
 #Test orthogonalization methods
 using Base.Test
 
+debug = false
 m=n=4
 A=randn(m, n)
 
 QRhouseholder = qr(A, thin=false)
 
-QRcgs = qrfact!(A, cgs)
-
-@test norm(QRhouseholder[1] - QRcgs.Q) % 1 < m*n*eps()
-@test_approx_eq abs(QRhouseholder[2]) abs(QRcgs.R)
-
+for algorithm in (cgs, cmgs)
+	debug && println(algorithm)
+	QRgs = qrfact!(copy(A), algorithm)
+	@test norm(QRhouseholder[1] - QRgs.Q) - iround(norm(QRhouseholder[1] - QRgs.Q)) < m*n*eps()
+	@test_approx_eq abs(QRhouseholder[2]) abs(QRgs.R)
+end

--- a/test/qr.jl
+++ b/test/qr.jl
@@ -1,0 +1,13 @@
+#Test orthogonalization methods
+using Base.Test
+
+m=n=4
+A=randn(m, n)
+
+QRhouseholder = qr(A, thin=false)
+
+QRcgs = qrfact!(A, cgs)
+
+@test norm(QRhouseholder[1] - QRcgs.Q) % 1 < m*n*eps()
+@test_approx_eq abs(QRhouseholder[2]) abs(QRcgs.R)
+

--- a/test/qr.jl
+++ b/test/qr.jl
@@ -5,11 +5,18 @@ debug = false
 m=n=4
 A=randn(m, n)
 
+srand(1)
+
 QRhouseholder = qr(A, thin=false)
 
-for algorithm in (cgs, cmgs)
-	debug && println(algorithm)
-	QRgs = qrfact!(copy(A), algorithm)
+for algorithm in (cgs, cmgs), normalization in (norm_none, norm_naive, norm_pythag)
+	debug && println(algorithm(nothing, normalization))
+	QRgs = qrfact!(copy(A), algorithm(nothing, normalization))
+	@test_approx_eq QRgs.Q*QRgs.R A
+	normalization == norm_none && continue
+	debug && @show QRhouseholder[1], QRgs.Q
+	debug && @show norm(QRhouseholder[1] - QRgs.Q) - iround(norm(QRhouseholder[1] - QRgs.Q)), m*n*eps()
 	@test norm(QRhouseholder[1] - QRgs.Q) - iround(norm(QRhouseholder[1] - QRgs.Q)) < m*n*eps()
+	debug && @show QRhouseholder[2], QRgs.R
 	@test_approx_eq abs(QRhouseholder[2]) abs(QRgs.R)
 end

--- a/test/qr.jl
+++ b/test/qr.jl
@@ -15,8 +15,8 @@ for algorithm in (cgs, cmgs), normalization in (norm_none, norm_naive, norm_pyth
 	@test_approx_eq QRgs.Q*QRgs.R A
 	normalization == norm_none && continue
 	debug && @show QRhouseholder[1], QRgs.Q
-	debug && @show norm(QRhouseholder[1] - QRgs.Q) - iround(norm(QRhouseholder[1] - QRgs.Q)), m*n*eps()
-	@test norm(QRhouseholder[1] - QRgs.Q) - iround(norm(QRhouseholder[1] - QRgs.Q)) < m*n*eps()
+	debug && @show norm(QRhouseholder[1] - QRgs.Q) - iround(norm(QRhouseholder[1] - QRgs.Q)), m^2*n^2*eps()
+	@test abs(norm(QRhouseholder[1] - QRgs.Q) - iround(norm(QRhouseholder[1] - QRgs.Q))) < m^2*n^2*eps()
 	debug && @show QRhouseholder[2], QRgs.R
 	@test_approx_eq abs(QRhouseholder[2]) abs(QRgs.R)
 end

--- a/test/qr.jl
+++ b/test/qr.jl
@@ -16,7 +16,7 @@ debug && @show QRhouseholder
 
 for algorithm in (cgs, cmgs)
 	for normalization in (norm_none, norm_naive, norm_pythag)
-		for reorth_criterion in (never, always, rutishauser(√2), giraudlangou(10.0))
+		for reorth_criterion in (never, always, rutishauser(sqrt(2)), giraudlangou(10.0))
 			debug && println(algorithm(nothing, normalization, ReorthogonalizationAlg(reorth_criterion)))
 			QRgs = qrfact!(copy(A), algorithm(nothing, normalization, ReorthogonalizationAlg(reorth_criterion)))
 			@test_approx_eq QRgs.Q*QRgs.R A

--- a/test/qr.jl
+++ b/test/qr.jl
@@ -7,7 +7,11 @@ srand(1)
 m=n=3
 A=randn(m, n) |> float32
 
-QRhouseholder = qr(A, thin=false)
+if v"0.2" <= VERSION < v"0.3-"
+    QRhouseholder = qr(A, false)
+else
+    QRhouseholder = qr(A, thin=false)
+end
 debug && @show QRhouseholder
 
 for algorithm in (cgs, cmgs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using IterativeSolvers
 using Base.Test
-const n=10
-const m=6
+n=10
+m=6
 srand(1234321)
 
 include("common.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ srand(1234321)
 
 include("common.jl")
 
-include("qr.jl")
+VERSION <= v"0.3-" || include("qr.jl")
 
 ##################
 # Linear solvers #

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,8 @@ srand(1234321)
 
 include("common.jl")
 
+include("qr.jl")
+
 ##################
 # Linear solvers #
 ##################


### PR DESCRIPTION
This PR will eventually provide several iterative orthogonalization algorithms for constructing an orthogonal basis for a vector space. The literature makes a big deal about controlling for loss of orthogonality in iterative methods, and so this is my attempt to throw the kitchen sink at the problem by providing the more widely touted variants of Gram-Schmidt orthogonalization. (If nothing else, users should be able to test these claims of orthogonality loss by having fine-grained control over the orthogonalization steps.)

The key design consideration here is how to provide these methods, which form the underlying basis (so to speak) of iterative linear solvers and eigensystem solvers, in a way that is composable and user-controllable.  The interface exposed herein is inspired by the sorting algorithms in `Base` and the [SortingAlgorithms.jl](http://github.com/JuliaLang/SortingAlgorithms.jl) package, where a single generic function is declared and methods are defined for each concrete algorithm. Similarly, this PR exposes new overloaded methods for `qrfact!` and dispatches on abstract `OrthogonalizationAlg <: Algorithm` subtypes. Unlike the sorting algorithms, however, the `Algorithm` subtypes also wrap parameters controlling for the number of iterations. The hope is that the abstract `Algorithm` interface will compose naturally with higher-level linear solvers and eigensolvers, allowing for the possibility of mixing and matching different orthogonalization routines over the course of an iterative solve.

To-do
- [x] Implement classical Gram-Schmidt
- [ ] Implement modified Gram-Schmidt
- [x] Implement columnwise modified Gram-Schmidt
- [x] Implement the Pythagorean variant of the QR normalization routine, which loses precision more slowly
- [x] Refactor the existing `qrfact!` methods to use the `normalize!` methods
- [ ] Implement the Cholesky variant of Gander, 1980
- [ ] Implement Rutishauser's superothogonalization
- [x] Implement backward- and forward- reorthogonalizing variants
- [ ] Implement adaptively reorthogonalizing variants using Rutishauser's and Giraud-Langou's criteria
- [ ] Implement Businger-Golub style partial QR decompositions (using a Frobenius norm threshold)
- [ ] Implement devectorized methods for dense matrices and vectors
- [ ] Allow the orthogonalization to be continued from a given partially orthogonalized iteration state
- [ ] Tests using Lauchli's example
