### PR TITLE
WIP: Experimental version of cg_hs iterator

### DIFF
--- a/src/cg.jl
+++ b/src/cg.jl
@@ -1,39 +1,110 @@
 export cg, cg!
 
-cg(A, b, Pl=1; kwargs...) =  cg!(zerox(A,b), A, b, Pl; kwargs...)
+import Base: start, next, done
+abstract IterativeSolver
+abstract IterationState
 
-function cg!(x, A, b, Pl=1; tol::Real=size(A,2)*eps(), maxiter::Int=size(A,2))
-    K = KrylovSubspace(A, length(b), 1, Vector{Adivtype(A,b)}[])
-    init!(K, x)
-    cg!(x, K, b, Pl; tol=tol, maxiter=maxiter)
+immutable KrylovSpace #XXX to replace KrylovSubspace
+    A
+    v0 :: Vector
 end
 
-function cg!(x, K::KrylovSubspace, b, Pl=1;
-        tol::Real=size(K.A,2)*eps(), maxiter::Integer=size(K.A,2))
-    resnorms = zeros(maxiter)
+#####################
+# Stopping criteria #
+#####################
 
-    tol = tol * norm(b)
-    r = b - nextvec(K)
-    p = z = isa(Pl, Function) ? Pl(r) : Pl\r
-    γ = dot(r, z)
-    for iter=1:maxiter
-        append!(K, p)
-        q = nextvec(K)
-        α = γ/dot(p, q)
-        α>=0 || throw(PosSemidefException("α=$α"))
-        update!(x, α, p)
-        r -= α*q
-        resnorms[iter] = norm(r)
-        if resnorms[iter] < tol #Converged?
-            resnorms = resnorms[1:iter]
-            break
+abstract stopcriterion
+
+immutable stopcriteriastate{T}
+    iter :: Int
+    resnorm² :: T
+end
+
+immutable maxiterations <: stopcriterion
+    maxiter :: Int
+end
+done(criterion::maxiterations, current::stopcriteriastate) = 
+    current.iter>=criterion.maxiter
+
+immutable absresnorm{T<:Real} <: stopcriterion
+    threshold :: T
+end
+done(criterion::absresnorm, current::stopcriteriastate) =
+    current.resnorm²<criterion.threshold^2
+
+#This termination criterion gets replaced by an absresnorm
+#once a resnorm is computed (its continuation is an absresnorm)
+immutable relresnorm{T<:Real} <: stopcriterion
+    relthreshold :: T
+end
+#If this criterion is still around, the starting norm is
+#unknown and there's no way to know if it should stop
+done(criterion::relresnorm, current::stopcriteriastate) =
+    false
+
+type Terminator
+    criteria :: Vector{stopcriterion}
+end
+push!(T::Terminator, criterion::stopcriterion) =
+    push!(T.criteria, criterion)
+
+function done(termination::Terminator, currentstate::stopcriteriastate)
+    for (idx, criterion) in enumerate(termination.criteria)
+        if isa(criterion, relresnorm) && isfinite(currentstate.resnorm²)
+            #There is a computed resnorm, so replace the
+            #relative criterion it by its continuation as an absresnorm
+            #Be careful to preserve ordering of criteria
+            #since we are modifying the list while iterating over it
+            deleteat!(termination.criteria, idx)
+            insert!(termination.criteria, idx,
+                absresnorm(criterion.relthreshold*√currentstate.resnorm²))
+        else #check if current criterion is good to terminate
+            done(criterion, currentstate) && return true
         end
-        z = isa(Pl, Function) ? Pl(r) : Pl\r
-        oldγ = γ
-        γ = dot(r, z)
-        β = γ/oldγ
-        p = z + β*p
-      end
-    x, ConvergenceHistory(0<resnorms[end]<tol, tol, K.mvps, resnorms)
+    end
+    return length(termination.criteria)==0 #If no criteria, always terminate
 end
 
+################################
+# Conjugate gradients          #
+# The Hestenes-Stiefel variant #
+################################
+
+immutable cg_hs <: IterativeSolver
+    K :: KrylovSpace
+    t :: Terminator
+end
+
+immutable cg_hs_state <: IterationState
+    r :: Vector #The current residual
+    p :: Vector #The current search direction
+    ts:: stopcriteriastate
+        #contains
+        # - Squared norm of the _previous_ residual
+        # - Current iteration
+end
+
+start(a::cg_hs) = cg_hs_state(a.K.v0, zeros(size(a.K.v0, 1)), stopcriteriastate(1, norm(a.K.v0)))
+
+#TODO Slot in preconditioners
+function next(a::cg_hs, old::cg_hs_state)
+    resnorm² = dot(old.r, old.r)
+    p = isfinite(old.ts.resnorm²) ? old.r + (resnorm² / old.ts.resnorm²) * old.p :
+                                    old.r
+    Ap = a.K.A*p
+    µ = resnorm² / dot(p, Ap)
+    µ*p, cg_hs_state(old.r-µ*Ap, p, stopcriteriastate(old.ts.iter+1, resnorm²))
+end
+
+done(a::cg_hs, currentstate::cg_hs_state) = done(a.t, currentstate.ts)
+
+##################
+# Generic solver #
+##################
+
+cg(A, b, Pl=1; kwargs...) = cg!(zerox(A,b), A, b, Pl; kwargs...)
+
+# TODO return ConvergenceHistories
+function cg!(x, A, b, Pl=1; tol::Real=size(A,2)*eps(), maxiter::Int=size(A,2))
+    solve(A, b, x, maxiter, cg_hs)
+end


### PR DESCRIPTION
This branch contains an implementation of conjugate gradients as an iterator. The algorithm is implemented entirely using the Julia iterator protocol, which implements methods for `start`, `next` and `done`.

In this paradigm:
- `start` initializes the algorithm
- `next` takes a single conjugate gradient step, and 
- `done` checks the termination criteria

This branch introduce new types:
- `IterativeSolver` encapsulates the parameters used to initialize the iterative algorithm, which is further decomposable into:
  - `KrylovSpace`: the associated Krylov subspace
  - `Terminator`: all the termination criteria, which is composed of
    - `stopcriterion`: a single termination criterion
- `IterationState` represents the state of the iterative algorithm

Conceptual todos:
- [ ] Figure out a representation of preconditioners. I think they are associated with the `KrylovSpace`...
- [ ] Figure out a representation of `ConvergenceHistory` in this design space

Thoughts so far:
- The separation of iteration state has helped clarify how cg_hs works; there is a clear separation of old and new quantities.
- The iterator protocol allows for a very clean abstraction of termination criteria. Just about every iterative solver algorithm here will be able to use the same `Terminator` and `stopcriterion` pieces to test for `done`ness.
- There is also a cute trick here (which may be too cute) in which a relative norm criterion is initializable even when the initial norm is not known, and is swapped out in favor of an absolute norm criterion once such the norm of the residual vector is computed.
