### PR TITLE
WIP: Implicitly restarted Arnoldi factorizers

### DIFF
--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -190,6 +190,11 @@ for (iter, Ar) in enumerate(Restarted(Arnoldi(K, Terminator(1e-9, n)), n))
     @assert abs(norm(K.A*Ar.V-Ar.V*Ar.H) - norm(Ar.r)) < sqrt(eps())
 end
 
+function eigfact!(Ar::ArnoldiFact)
+    fact = eigfact!(Ar.H)
+    fact.values, Ar.V*fact.Q
+end
+
 # # References
 #
 # 1. D. C. Sorensen, "Implicit application of polynomial filters in a $k$-step Arnoldi method", _SIAM J. Matrix Anal. Appl._ 13 (1), pp. 357-385, January 1992. [doi:10.1137/0613025](http://epubs.siam.org/doi/abs/10.1137/0613025)

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -1,4 +1,4 @@
-import Base: start, next, done, eigfact!, eigvals
+import Base: start, next, done, eigfact!, eigfact, eigvals
 
 #The usual Krylov space machinery
 type Krylov{T}
@@ -214,6 +214,8 @@ function eigfact!(Ar::ArnoldiFact; purge::Bool=false)
     Base.Eigen(evals, evecs)
 end
 
+eigfact(Ar::ArnoldiFact; purge::Bool=false) =
+    eigfact!(ArnoldiFact(Ar.V, copy(Ar.H), Ar.r), purge=purge)
 eigvals(Ar::ArnoldiFact) = eigvals(Ar.H)
 
 # Test of implicitly and explicitly restarted Arnoldi iterators

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -1,4 +1,4 @@
-import Base: start, next, done
+import Base: start, next, done, eigfact!, eigvals
 
 #The usual Krylov space machinery
 type Krylov{T}
@@ -194,6 +194,8 @@ function eigfact!(Ar::ArnoldiFact)
     fact = eigfact!(Ar.H)
     fact.values, Ar.V*fact.Q
 end
+
+eigvals(Ar::ArnoldiFact) = eigvals(Ar.H)
 
 # # References
 #

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -1,0 +1,111 @@
+import Base: start, next, done
+
+#The usual Krylov space machinery
+type Krylov{T}
+    A
+    v₀ :: AbstractVector{T}
+end
+
+#Termination criteria
+type Terminator{T}
+    tol :: T
+    maxiter :: Int
+end
+
+# __Definition 2.1.__ The Arnoldi factorization is a truncated Hessenberg factorization of a matrix $A$ such that
+#
+# $$ AV = VH + r e_k^T $$
+#
+# where $V \in \mathbb{R}^{n\times k}$, $V^T V = I_k$, $H \in \mathbb{R}^{k\times k}$ is upper Hessenberg, $r \in \mathbb{R}^n$ with $0=V^T r$.
+
+type ArnoldiFact{T} <: Factorization{T}
+    V :: Matrix{T}
+    H :: Matrix{T}
+    r :: Vector{T}
+end
+
+function ArnoldiFact{T}(V::Matrix{T}, H::Matrix{T}, r::Vector{T})
+    #Check dimensions
+    @assert size(V,2) == size(H,1)
+    @assert size(V,1) == size(r,1)
+    ArnoldiFact{T}(V, H, r)
+end
+
+#The Arnoldi iterator
+
+abstract Factorizer
+
+type Arnoldi{T} <: Factorizer
+    K :: Krylov{T}
+    term :: Terminator{T}
+end
+
+function start{T}(P::Arnoldi{T})
+    r = P.K.v₀
+    n = size(r, 1)
+    V = zeros(T,n,0)
+    H = zeros(T,0,0)
+    ArnoldiFact{T}(V, H, r)
+end
+
+# To write out the algorithms later, it's also convenient to define this `UnitVec` type which represents the canonical basis vector $e_k$. The nice thing is that pre-/post-multiplying $A$ by $e_k$ is equivalent to extracting the $k$th row or column of $A$ respectively.
+type UnitVec
+    k :: Int
+end
+
+*(A::AbstractArray, e::UnitVec) = A[:,e.k]
+*(e::UnitVec, A::AbstractArray) = A[e.k,:]
+
+# __The `Arnoldi` function (Algorithm 3.7; Sorensen, 1992)__.
+#
+# Input: $AV - VH = re_k^T$ with $V^T V = I_k, V^T r = 0$
+#
+# Output: $AV - VH = re_{k+p}^T$ with $V^T V = I_{k+p}, V^T r = 0$
+
+function next{T}(P::Arnoldi{T}, F::ArnoldiFact{T})
+    V, H, r = F.V, F.H, F.r
+    β = norm(r)
+
+    H = size(H,2)==0 ? zeros(1,0) :
+      [H; [zeros(1,size(H,2)-1) β]]
+    v = r / β
+    V = [V v]
+
+    w = K.A*v
+
+    h = V'w
+    H = [H h]
+
+    r = w - V*h
+    #Gram-Schmidt
+    for i=1:2
+      s = V'r
+      r-= V*s
+      h+= s
+      norm(s) < P.term.tol*norm(r) && break
+    end
+    @assert abs(norm(K.A*V-V*H) - norm(r)) < P.term.tol
+    F  = ArnoldiFact(V, H, r)
+    F, F
+end
+
+function done{T}(P::Arnoldi{T}, F::ArnoldiFact{T})
+    #TODO maxiter
+    β = norm(F.r)
+    β < P.term.tol
+end
+
+#Test of Arnoldi iterator
+
+n=10
+M=randn(n,n)#;M+=M'
+K = Krylov(M, randn(n))
+for (iter, Ar) in enumerate(Arnoldi(K, Terminator(1e-9, n)))
+    println("Iteration $iter:\t residual norm = ", norm(Ar.r))
+    @assert abs(norm(K.A*Ar.V-Ar.V*Ar.H) - norm(Ar.r)) < sqrt(eps())
+end
+
+
+# # References
+#
+# 1. D. C. Sorensen, "Implicit application of polynomial filters in a $k$-step Arnoldi method", _SIAM J. Matrix Anal. Appl._ 13 (1), pp. 357-385, January 1992. [doi:10.1137/0613025](http://epubs.siam.org/doi/abs/10.1137/0613025)


### PR DESCRIPTION
This PR contains very naïve (but working!) implementations of the Arnoldi method for iteratively constructing partial Hessenberg factorizations (equivalently, Arnoldi factorizations, incomplete Hessenberg factorizations, or truncated Hessenberg factorizations), as encapsulated in the `ArnoldiFactorization` type which wraps the partial Hessenberg factorization (_H_, _V_) and the residual vector _r_ such that

![image](https://cloud.githubusercontent.com/assets/1732/4244520/2c4e5984-3a23-11e4-97ee-13204270cc17.png)

Explicitly restarted and implicitly restarted variants of Arnoldi are also implemented as `Restarted{Arnoldi}` and `ImplicitlyRestarted{Arnoldi}`. (The implicitly restarted Arnoldi method is the core numerical algorithm underlying ARPACK.) These iterators are constructed from `Restarted` and `ImplicitlyRestarted`; both are parametric `Factorizer` types which are themselves parametric on an underlying `Factorizer`. The idea is to factor out the the techniques for restarting the factorization process from the underlying factorization process itself. (It could easily be symmetric Lanczos or biorthogonal Lanczos instead, where the underlying matrix factorization object is the tridiagonal analogue of the Arnoldi factorization.)

There is a lot to do here:
- [ ] Figure out what to export
- [ ] The `Arnoldi` process should become parametric on the orthogonalization method (#28)
- [ ] Consolidate the `Arnoldi` iterator with implementations in other algorithms like GMRES
- [ ] The `Terminator` type should be consistent with #29
- [ ] The `Shifts` function should provide most (if not all) of the various spectral partitioning methods described in the ARPACK documentation. Currently, only the `LM` (largest magnitude) mode is implemented. The nice thing is that Julia allows users to specify a custom rule for partitioning the spectrum as a function (the `by` keyword argument of `Shifts`).
- [ ] The deflation step in `ImplicitlyRestarted{Arnoldi}` should be replaced with the bulge-chasing version of the implicitly shift QR update, which is much more efficient.
- [ ] Is there a "thin" version of the matrix factorization? What is the bare minimum state needed to be saved during the iteration process?
