### PR TITLE
Eigenvalue computation using implicitly restarted Arnoldi method

### DIFF
--- a/src/IterativeSolvers.jl
+++ b/src/IterativeSolvers.jl
@@ -4,6 +4,7 @@ isdefined(:__precompile__) && __precompile__(true)
 
 include("common.jl")
 include("krylov.jl")
+include("hessenqr.jl")
 
 #Specialized factorizations
 include("factorization.jl")
@@ -18,6 +19,7 @@ include("idrs.jl")
 #Eigensolvers
 include("simple.jl")
 include("lanczos.jl")
+include("arnoldi.jl")
 
 #SVD solvers
 include("svdl.jl")

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -1,0 +1,226 @@
+export eigvals_arnoldi
+
+## Arnoldi factorization starting from step-k
+function arnoldifac!{T}(k::Int, m::Int, V::Matrix{T}, H::Matrix{T}, f::Vector{T}, A, prec::T)
+    if m <= k
+        error("m must be greater than k")
+    end
+
+    ## Keep the upperleft k x k submatrix of H and
+    ## set other elements to 0
+    H[:, (k + 1):end] = zero(T)
+    H[(k + 1):end, 1:k] = zero(T)
+
+    beta::T = norm(f)
+
+    for i = k:(m - 1)
+        ## V{i+1} <- f / ||f||
+        V[:, i + 1] = f / beta
+        H[i + 1, i] = beta
+
+        ## w <- A * V{i+1}
+        w::Vector{T} = A * V[:, i + 1]
+
+        H[i, i + 1] = beta
+        H[i + 1, i + 1] = dot(V[:, i + 1], w)
+
+        ## f <- w - V * V' * w
+        f[:] = w - beta * V[:, i] - H[i + 1, i + 1] * V[:, i + 1]
+        beta = norm(f)
+
+        ## f/||f|| is going to be the next column of V, so we need to test
+        ## whether V' * (f/||f||) ~= 0
+        Vf::Vector{T} = V[:, 1:(i + 1)]' * f
+        count = 0
+        while count < 5 && maximum(abs(Vf)) > prec * beta
+            ## f <- f - V * Vf
+            f[:] -= V[:, 1:(i + 1)] * Vf
+            ## h <- h + Vf
+            H[i, i + 1] += Vf[i]
+            H[i + 1, i] = H[i, i + 1]
+            H[i + 1, i + 1] += Vf[i + 1]
+            ## beta <- ||f||
+            beta = norm(f)
+
+            Vf[:] = V[:, 1:(i + 1)]' * f
+            count += 1
+        end
+    end
+end
+
+## Apply shifts on V, H and f
+function applyshifts!{T}(k::Int, V::Matrix{T}, H::Matrix{T}, f::Vector{T}, shifts::Vector{T})
+    n = size(V, 1)
+    ncv = size(V, 2)
+    Q::Matrix{T} = eye(T, ncv)
+
+    for i = (k + 1):ncv
+        ## QR decomposition of H-mu*I, mu is the shift
+        for j = 1:ncv
+            H[j, j] -= shifts[i]
+        end
+        qr = tridiagqr!(H)  ## H -> RQ
+        applyright!(qr, Q)  ## Q -> Q * Qi
+        for j = 1:ncv
+            H[j, j] += shifts[i]
+        end
+    end
+
+    ## V -> VQ, only need to update the first k+1 columns
+    ## Q has some elements being zero
+    ## The first (ncv - k + i) elements of the i-th column of Q are non-zero
+    # Vs = zeros(T, n, k + 1)
+    # for i = 1:k
+    #     nnz = ncv - k + i
+    #     Vs[:, i] = V[:, 1:nnz] * Q[1:nnz, i]
+    # end
+    # Vs[:, k + 1] = V * Q[:, k + 1]
+    # V[:, 1:(k + 1)] = Vs
+    ## However this seems to be slower than a direct multiplication
+
+    ## V -> VQ
+    V[:, :] = V * Q
+    f[:] = f * Q[ncv, k] + V[:, k + 1] * H[k + 1, k]
+end
+
+## Retrieve Ritz values and Ritz vectors
+function ritzpairs!{T}(which::Symbol, H::Matrix{T}, ritzval::Vector{T}, ritzvec::Matrix{T}, ritzest::Vector{T})
+    ncv = size(ritzvec, 1)
+    neigs = size(ritzvec, 2)
+    ## Eigen decomposition on H, which is symmetric and tridiagonal
+    decomp = eigfact(SymTridiagonal(diag(H), diag(H, -1)))
+
+    ## Sort Ritz values according to "which"
+    if which == :LM
+        trans = abs
+        rev = true
+    elseif which == :SM
+        trans = abs
+        rev = false
+    elseif which == :LA || which == :BE
+        trans = (x -> x)
+        rev = true
+    else which == :SA
+        trans = (x -> x)
+        rev = false
+    end
+
+    ix = sortperm(decomp.values, by = trans, rev = rev)
+
+    if which == :BE
+        ixcp = copy(ix)
+        for i = 1:ncv
+            if i % 2 == 1
+                ix[i] = ixcp[(i + 1) / 2]
+            else
+                ix[i] = ixcp[ncv - i / 2 + 1]
+            end
+        end
+    end
+
+    ritzval[:] = decomp.values[ix]
+    ritzest[:] = decomp.vectors[ncv, ix]
+    ritzvec[:, :] = decomp.vectors[:, ix[1:neigs]]
+end
+
+## Adjusted neigs
+function neigsadjusted{T}(neigs::Int, ncv::Int, nconv::Int, ritzest::Vector{T}, prec::T)
+    neigsnew = neigs + sum(abs(ritzest[(neigs + 1):ncv]) .< prec)
+    neigsnew += min(nconv, div(ncv - neigsnew, 2))
+    if neigsnew == 1 && ncv >= 6
+        neigsnew = div(ncv, 2)
+    elseif neigsnew == 1 && ncv > 2
+        neigsnew = 2
+    end
+
+    return neigsnew
+end
+
+function eigvals_arnoldi(A, neigs::Int = 6;
+                         ncv::Int = min(size(A, 1), max(2 * neigs + 1, 20)),
+                         which::Symbol = :LM,
+                         tol::Real = sqrt(eps(eltype(A))),
+                         maxiter::Int = 300,
+                         returnvec::Bool = true,
+                         v0 = rand(eltype(A), size(A, 1)) - convert(eltype(A), 0.5))
+    T = eltype(A)
+    ## Size of matrix
+    n = size(A, 1)
+    ## Check arguments
+    if neigs < 1 || neigs > n - 1
+        error("neigs must satisfy 1 <= neigs <= n - 1, n is the size of matrix")
+    end
+    if ncv <= neigs || ncv > n
+        error("ncv must satisfy neigs < ncv <= n, n is the size of matrix")
+    end
+
+    ## Number of matrix operations called
+    nmatop::Int = 0
+    ## Number of restarting iteration
+    niter::Int = maxiter
+    ## Number of converged eigenvalues
+    nconv::Int = 0
+
+    ## Matrices and vectors in the Arnoldi factorization
+    V::Matrix{T} = zeros(T, n, ncv)
+    H::Matrix{T} = zeros(T, ncv, ncv)
+    f::Vector{T} = zeros(T, n)
+    ritzval::Vector{T} = zeros(T, ncv)
+    ritzvec::Matrix{T} = zeros(T, ncv, neigs)
+    ritzest::Vector{T} = zeros(T, ncv)
+    ritzconv::Vector{Bool} = zeros(Bool, neigs)
+
+    ## Precision parameter used to test convergence
+    prec::T = eps(T)^(convert(T, 2.0) / 3)
+
+    ## Initialize vectors
+    v0norm = norm(v0)
+    if v0norm < prec
+        error("initial residual vector cannot be zero")
+    end
+    v0[:] /= v0norm
+    w::Vector{T} = A * v0
+    nmatop += 1
+    H[1, 1] = dot(v0, w)
+    f[:] = w - v0 * H[1, 1]
+    V[:, 1] = v0
+
+    ## First Arnoldi factorization
+    arnoldifac!(1, ncv, V, H, f, A, prec)
+    nmatop += (ncv - 1)
+    ritzpairs!(which, H, ritzval, ritzvec, ritzest)
+    ## Restarting
+    thresh::Vector{T} = zeros(T, neigs)
+    resid::Vector{T} = zeros(T, neigs)
+    for i = 1:maxiter
+        ## Convergence test
+        thresh[:] = tol * max(abs(ritzval[1:neigs]), prec)
+        resid[:] = abs(ritzest[1:neigs]) * norm(f)
+        ritzconv[:] = (resid .< thresh)
+        nconv = sum(ritzconv)
+
+        if nconv >= neigs
+            niter = i
+            break
+        end
+
+        neigsadj::Int = neigsadjusted(neigs, ncv, nconv, ritzest, prec)
+
+        applyshifts!(neigsadj, V, H, f, ritzval)
+        arnoldifac!(neigsadj, ncv, V, H, f, A, prec)
+        nmatop += (ncv - neigsadj)
+        ritzpairs!(which, H, ritzval, ritzvec, ritzest)
+    end
+
+    ## Final sorting of Ritz values
+    ix = sortperm(ritzval[1:neigs], by = abs, rev = true)
+    converged = ix[ritzconv[ix]]
+    eigval = ritzval[converged]
+    if returnvec
+        eigvec = V * ritzvec[:, converged]
+    else
+        eigvec = nothing
+    end
+
+    return eigval, eigvec, nconv, niter, nmatop
+end

--- a/src/hessenqr.jl
+++ b/src/hessenqr.jl
@@ -1,0 +1,157 @@
+immutable HessenbergQR{T}
+    cosθ::Vector{T}
+    sinθ::Vector{T}
+end
+
+## QR decomposition on an upper Hessenberg matrix
+## H will be overwritten by Q'HQ=RQ
+function hessenqr!{T}(H::Matrix{T})
+    ## Size of matrix
+    n = size(H, 1)
+    if n != size(H, 2)
+        error("matrix must be square")
+    end
+
+    ## Rotation factors
+    ## Each pair (cosθ[i], sinθ[i]) forms a rotation matrix
+    ## Gi = [cosθ[i]  -sinθ[i]]
+    ##      [sinθ[i]   cosθ[i]]
+    cosθ = ones(T, n)
+    sinθ = zeros(T, n)
+
+    for i = 1:(n - 1)
+        ## Make sure H is upper Hessenberg
+        ## Zero the elements below H[i+1, i]
+        H[(i + 2):end, i] = zero(T)
+        ## Calculate cosθ and sinθ
+        x = H[i, i]
+        y = H[i + 1, i]
+        r = hypot(x, y)
+        ## If r is too small, (cosθ, sinθ) stores the original values (1, 0)
+        if r < eps(T)
+            r = zero(T)
+        else
+            cosθ[i] = x / r
+            sinθ[i] = -y / r
+        end
+        ## Apply the rotation on the left H -> Gi * H
+        ## H[i, :]     <- cosθ[i] * H[i, :] - sinθ[i] * H[i +1, :]
+        ## H[i + 1, :] <- sinθ[i] * H[i, :] + cosθ[i] * H[i +1, :]
+        H[i, i] = r
+        H[i + 1, i] = zero(T)
+        c = cosθ[i]
+        s = sinθ[i]
+        for j = (i + 1):n
+            tmp = H[i, j]
+            H[i, j]     = c * tmp - s * H[i + 1, j]
+            H[i + 1, j] = s * tmp + c * H[i + 1, j]
+        end
+    end
+
+    ## Apply the rotations on the right H -> H * Gi'
+    ## H[:, i]     <- cosθ[i] * H[:, i] - sinθ[i] * H[:, i + 1]
+    ## H[:, i + 1] <- sinθ[i] * H[:, i] + cosθ[i] * H[:, i + 1]
+    for i = 1:(n - 1)
+        for j = 1:(i + 1)
+            tmp = H[j, i]
+            H[j, i]     = cosθ[i] * tmp - sinθ[i] * H[j, i + 1]
+            H[j, i + 1] = sinθ[i] * tmp + cosθ[i] * H[j, i + 1]
+        end
+    end
+
+    return HessenbergQR(cosθ, sinθ)
+end
+
+## QR decomposition on a tridiagonal matrix
+## H will be overwritten by Q'HQ=RQ
+function tridiagqr!{T}(H::Matrix{T})
+    ## Size of matrix
+    n = size(H, 1)
+    if n != size(H, 2)
+        error("matrix must be square")
+    end
+
+    ## Force H to be tridiagonal
+    maindiag = diag(H)
+    subdiag = diag(H, -1)
+    fill!(H, zero(T))
+    for i = 1:(n - 1)
+        H[i, i] = maindiag[i]
+        H[i + 1, i] = subdiag[i]
+        H[i, i + 1] = subdiag[i]
+    end
+    H[n, n] = maindiag[n]
+
+    ## Rotation factors
+    ## Each pair (cosθ[i], sinθ[i]) forms a rotation matrix
+    ## Gi = [cosθ[i]  -sinθ[i]]
+    ##      [sinθ[i]   cosθ[i]]
+    cosθ = ones(T, n)
+    sinθ = zeros(T, n)
+
+    for i = 1:(n - 1)
+        ## Calculate cosθ and sinθ
+        x = H[i, i]
+        y = H[i + 1, i]
+        r = hypot(x, y)
+        ## If r is too small, (cosθ, sinθ) stores the original values (1, 0)
+        if r < eps(T)
+            r = zero(T)
+        else
+            cosθ[i] = x / r
+            sinθ[i] = -y / r
+        end
+        ## Apply the rotation on the left H -> Gi * H
+        ## Update H[i, i] and H[i + 1, i]
+        H[i, i] = r
+        H[i + 1, i] = zero(T)
+        ## Update H[i, i + 1] and H[i + 1, i + 1]
+        c = cosθ[i]
+        s = sinθ[i]
+        tmp = H[i, i + 1]
+        H[i,     i + 1] = c * tmp - s * H[i + 1, i + 1]
+        H[i + 1, i + 1] = s * tmp + c * H[i + 1, i + 1]
+        ## Update H[i, i + 2] and H[i + 1, i + 2]
+        if i < n - 1
+            H[i,     i + 2] = -s * H[i + 1, i + 2]
+            H[i + 1, i + 2] *= c
+        end
+    end
+
+    ## Apply the rotations on the right H -> H * Gi'
+    ## H[:, i]     <- cosθ[i] * H[:, i] - sinθ[i] * H[:, i + 1]
+    ## H[:, i + 1] <- sinθ[i] * H[:, i] + cosθ[i] * H[:, i + 1]
+    for i = 1:(n - 1)
+        c = cosθ[i]
+        s = sinθ[i]
+
+        tmp = H[i + 1, i]
+        H[i, i]         = c * H[i, i] - s * H[i, i + 1]
+        H[i + 1, i]     = c * tmp     - s * H[i + 1, i + 1]
+        H[i + 1, i + 1] = s * tmp     + c * H[i + 1, i + 1]
+
+        H[i, i + 1] = H[i + 1, i]
+        if i < n - 1
+            H[i, i + 2] = zero(T)
+        end
+    end
+
+    return HessenbergQR(cosθ, sinθ)
+end
+
+## Apply the QR factorization to the right of a matrix A
+## A -> A * Q'
+function applyright!{T}(qr::HessenbergQR{T}, A::Matrix{T})
+    cosθ = qr.cosθ
+    sinθ = qr.sinθ
+    n = length(cosθ)
+    ## A[:, i]     <- cosθ[i] * A[:, i] - sinθ[i] * A[:, i + 1]
+    ## A[:, i + 1] <- sinθ[i] * A[:, i] + cosθ[i] * A[:, i + 1]
+    for i = 1:(n - 1)
+        for j = 1:size(A, 1)
+            tmp = A[j, i]
+            A[j, i]     = cosθ[i] * tmp - sinθ[i] * A[j, i + 1]
+            A[j, i + 1] = sinθ[i] * tmp + cosθ[i] * A[j, i + 1]
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -229,11 +229,19 @@ type MyOp{T}
     buf::Matrix{T}
 end
 
+type MySpOp{T}
+    buf::SparseMatrixCSC{T}
+end
+
 import Base: *, size, eltype
 
 *(A::MyOp, x::AbstractVector) = A.buf*x
 size(A::MyOp, i) = size(A.buf, i)
 eltype(A::MyOp) = eltype(A.buf)
+
+*(A::MySpOp, x::AbstractVector) = A.buf*x
+size(A::MySpOp, i) = size(A.buf, i)
+eltype(A::MySpOp) = eltype(A.buf)
 
 facts("eigvals_lanczos") do
 for T in (Float32, Float64)
@@ -253,6 +261,57 @@ for T in (Float32, Float64)
         eval_lanczos, c_lanczos = eigvals_lanczos(A)
         @fact c_lanczos.isconverged --> true
         @fact norm(v - eval_lanczos) --> less_than(√eps(T))
+    end
+end
+end
+
+#Arnoldi methods
+
+facts("eigvals_arnoldi") do
+for T in (Float32, Float64)
+
+    A = convert(Matrix{T}, randn(100,100))
+    A = A + A' #Symmetric
+
+    context("Matrix{$T}") do
+        v = eigvals(A)
+        neigs = 10
+
+        eval_arnoldi, evec_arnoldi, nconv = eigvals_arnoldi(A, neigs, which = :LA)
+        @fact nconv --> neigs
+        @fact norm(sort(eval_arnoldi) - v[end-neigs+1:end]) --> less_than(√eps(T))
+    end
+
+    context("Op{$T}") do
+        Aop = MyOp(A)
+        v = eigvals(Symmetric(Aop.buf))
+        neigs = 10
+
+        eval_arnoldi, evec_arnoldi, nconv = eigvals_arnoldi(Aop, neigs, which = :LA)
+        @fact nconv --> neigs
+        @fact norm(sort(eval_arnoldi) - v[end-neigs+1:end]) --> less_than(√eps(T))
+    end
+
+    A = convert(SparseMatrixCSC{T}, sprandn(100,100,0.8))
+    A = A + A' #Symmetric
+
+    context("SpMat{$T}") do
+        v = eigvals(full(A))
+        neigs = 10
+
+        eval_arnoldi, evec_arnoldi, nconv = eigvals_arnoldi(A, neigs, which = :LA)
+        @fact nconv --> neigs
+        @fact norm(sort(eval_arnoldi) - v[end-neigs+1:end]) --> less_than(√eps(T))
+    end
+
+    context("SpOp{$T}") do
+        Aop = MySpOp(A)
+        v = eigvals(Symmetric(full(Aop.buf)))
+        neigs = 10
+
+        eval_arnoldi, evec_arnoldi, nconv = eigvals_arnoldi(Aop, neigs, which = :LA)
+        @fact nconv --> neigs
+        @fact norm(sort(eval_arnoldi) - v[end-neigs+1:end]) --> less_than(√eps(T))
     end
 end
 end


### PR DESCRIPTION
This is a follow-up of the discussion in #31.

It provides the function `eigvals_arnoldi()` that implements most functionality of `eigs()` on symmetric matrices. I haven't added the documentation yet, since the interface and arguments may change a lot depending on the discussion here. And since this function is intended to replace `eigs()` in the future, the documentation can be easily derived from `eigs()`.

There are some issues here:
1. The interface of this function is not consistent with `eigvals_lanczos()`, due to the nature of the Arnoldi method; in fact it is more similar to `eigs()`.
2. Computed eigenvalues are in decreasing order, to be consistent with `eigs()`.
3. The function is for symmetric linear operator only. I can also try to write a general eigen solver, but it takes more effort.
4. The test code causes one `svdl` test to fail, since it changed the state of the random seed. Sorry...
