### PR TITLE
Add blas sugar and blas optimizations to methods

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.5-
 
 UnicodePlots
 RecipesBase
+SugarBLAS

--- a/src/IterativeSolvers.jl
+++ b/src/IterativeSolvers.jl
@@ -1,6 +1,8 @@
 __precompile__(true)
 module IterativeSolvers
 
+using SugarBLAS
+
 include("common.jl")
 include("krylov.jl")
 include("history.jl")

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -54,8 +54,8 @@ function chebyshev_method!(
 			p = z + β*p
 		end
 		append!(K, p)
-		update!(x, α, p)
-		r -= α*nextvec(K)
+		@blas! x += α*p
+		@blas! r -= α*nextvec(K)
 		#Check convergence
 		resnorm = norm(r)
         push!(log, :resnorm, resnorm)

--- a/src/common.jl
+++ b/src/common.jl
@@ -27,13 +27,6 @@ function zerox(A, b)
 end
 
 #### Numerics
-function update!(x, α::Number, p::AbstractVector)
-    for i = 1:length(x)
-        x[i] += α*p[i]
-    end
-    x
-end
-
 function initrand!(v::Vector)
     _randn!(v)
     nv = norm(v)

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -114,7 +114,7 @@ function gmres_method!(log::ConvergenceHistory, x, A, b;
 
         @eval a = $(VERSION < v"0.4-" ? Triangular(H[1:N, 1:N], :U) \ s[1:N] : UpperTriangular(H[1:N, 1:N]) \ s[1:N])
         w = a[1:N] * K
-        update!(x, 1, Pr\w) #Right preconditioner
+        @blas! x = Pr\w #Right preconditioner
 
         if (rho<tol) | ((macroiter-1)*restart+N >= maxiter)
             setconv(log, rho<tol)

--- a/src/krylov.jl
+++ b/src/krylov.jl
@@ -75,13 +75,13 @@ function orthogonalize{T}(v::Vector{T}, K::KrylovSubspace{T}, p::Int=K.order;
     if method == :GramSchmidt
         cs = T[dot(e, v) for e in Kk]
         for (i, e) in enumerate(Kk)
-            v -= cs[i] * e
+            @blas! v -= cs[i] * e
         end
     elseif method == :ModifiedGramSchmidt
         cs = zeros(T, p)
         for (i, e) in enumerate(Kk)
             cs[i] = dot(e, v)
-            v-= cs[i] * e
+            @blas! v -= cs[i] * e
         end
     elseif method == :Householder
         #Use brute force Householder

--- a/src/stationary.jl
+++ b/src/stationary.jl
@@ -51,7 +51,7 @@ function jacobi_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b;
         push!(log,:resnorm,resnorm)
         verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
 		resnorm < tol && (setconv(log, resnorm>=0); break)
-		copy!(xold, x)
+		@blas! xold = x
 	end
     verbose && @printf("\n")
 	x
@@ -110,7 +110,7 @@ function gauss_seidel_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b;
         push!(log,:resnorm,resnorm)
         verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         resnorm < tol && (setconv(log, resnorm>=0); break)
-		copy!(xold, x)
+		@blas! xold = x
 	end
     verbose && @printf("\n")
 	x
@@ -172,7 +172,7 @@ function sor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real;
         push!(log,:resnorm,resnorm)
         verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         resnorm < tol && (setconv(log, resnorm>=0); break)
-		copy!(xold, x)
+		@blas! xold = x
 	end
     verbose && @printf("\n")
 	x
@@ -229,7 +229,7 @@ function ssor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real
 			σ=(b[i]-σ)/A[i,i]
 			x[i]=xold[i]+ω*(σ-xold[i])
 		end
-		copy!(xold, x)
+		@blas! xold = x
 		for i=n:-1:1 #Do a backward SOR sweep
 			σ=z
 			for j=1:i-1
@@ -247,7 +247,7 @@ function ssor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real
         push!(log,:resnorm,resnorm)
         verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         resnorm < tol && (setconv(log, resnorm>=0); break)
-		copy!(xold, x)
+		@blas! xold = x
 	end
     verbose && @printf("\n")
 	x

--- a/test/lsmr.jl
+++ b/test/lsmr.jl
@@ -68,6 +68,7 @@ function Base.fill!(a::DampenedVector, α::Number)
     return a
 end
 
+Base.scale!(α::Number, a::DampenedVector) = Base.scale!(a, α)
 function Base.scale!(a::DampenedVector, α::Number)
     scale!(a.y, α)
     scale!(a.x, α)


### PR DESCRIPTION
In response to issue #16 and #26 here I add blas optimizations to cg and krylov orthogonalization. The new internal macro `@blas!` matches between `scal!`, `scal`, `axpy!` or `blascopy!` (each of them with added robustness). If there is people interested in some form of blas sugar I wouldn't mind making a new package.

_Better to merge when the benchmarks are set_
