### PR TITLE
Replace AbstractMatrixCFcn for new type LinearMap

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -57,26 +57,37 @@ export FuncMatrix
 
 """
     FuncMatrix{T,A,B}
-Represent functions as a matrix.
+
+Represent functions as a matrix. `T` is the type of the elements inside of the
+'matrix' `(T == eltype(::FuncMatrix))`.
+
 **Fields**
+
 * `m::Int` = number of columns.
 * `n::Int` = number of rows.
 * `mul::Function` = `A*b` implementation.
 * `cmul::Function` = `A'*b` implementation.
+
 **Constructors**
+
     FuncMatrix(A)
     FuncMatrix(
         m::Int, n::Int; typ::Type=Float64, ctrans::Bool=false,
         mul::Function=identity, cmul=identity
     )
+
 **Arguments**
+
 * `A::AbstractMatrix` = matrix.
 * `m::Int` = number of columns.
 * `n::Int` = number of rows.
 * `typ::Type = Float64` = `eltype(::FuncMatrix)`.
 * `mul::Function = identity` = `A*b` implementation.
 * `cmul::Function = identity` = `A'*b` implementation.
+
 """
+#A is true if mul is different from identity, otherwise it is false.
+#The same happens for B with cmul.
 type FuncMatrix{T,A,B}
     m::Int
     n::Int

--- a/src/common.jl
+++ b/src/common.jl
@@ -58,8 +58,10 @@ export LinearMap
 """
     LinearMap{T,A,B}
 
-Represent functions as a matrix. `T` is the type of the elements inside of the
-'matrix' `(T == eltype(::LinearMap))`.
+Represent a finite dimensional linear map as a function describing
+its application (a matrix-vector product) and also, optionally, its transpose
+
+`T` is the element type of the vector produced by the map.
 
 **Fields**
 
@@ -71,17 +73,16 @@ Represent functions as a matrix. `T` is the type of the elements inside of the
 **Constructors**
 
     LinearMap(A)
-    LinearMap(
-        m::Int, n::Int; typ::Type=Float64, ctrans::Bool=false,
-        mul::Function=identity, cmul=identity
-    )
+    LinearMap(m, n)
+    LinearMap(typ, m, n)
 
 **Arguments**
 
 * `A::AbstractMatrix` = matrix.
 * `m::Int` = number of columns.
 * `n::Int` = number of rows.
-* `typ::Type = Float64` = `eltype(::LinearMap)`.
+* `typ::Type` = element type of the vector produced by the map, if not given
+`T` defaults to Float64.
 * `mul::Function = identity` = `A*b` implementation.
 * `cmul::Function = identity` = `A'*b` implementation.
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -59,7 +59,7 @@ export LinearMap
     LinearMap{T,A,B}
 
 Represent a finite dimensional linear map as a function describing
-its application (a matrix-vector product) and also, optionally, its transpose
+its application (a matrix-vector product) and also, optionally, its transpose.
 
 `T` is the element type of the vector produced by the map.
 

--- a/src/rlinalg.jl
+++ b/src/rlinalg.jl
@@ -282,7 +282,10 @@ immutable srft{T<:Integer}
     l :: T
 end
 
-(*)(A::AbstractMatrixFcn, B::srft) = error("method only defined to avoid ambiguity. If you need this method please open a pull request")
+(*)(A::FuncMatrix, B::srft) = error(
+    "method only defined to avoid ambiguity. " *
+    "If you need this method please open a pull request"
+    )
 
 @doc doc"""
 Applies a subsampled random Fourier transform to the columns of `A`

--- a/src/rlinalg.jl
+++ b/src/rlinalg.jl
@@ -282,7 +282,7 @@ immutable srft{T<:Integer}
     l :: T
 end
 
-(*)(A::FuncMatrix, B::srft) = error(
+(*)(A::LinearMap, B::srft) = error(
     "method only defined to avoid ambiguity. " *
     "If you need this method please open a pull request"
     )

--- a/test/cg.jl
+++ b/test/cg.jl
@@ -47,7 +47,7 @@ context("Sparse Laplacian") do
         @fact norm(A*xJAC - rhs) --> less_than_or_equal(tol)
     end
 
-    Af = FuncMatrix(A)
+    Af = LinearMap(A)
     context("function") do
         xCG, = cg(Af,rhs;tol=tol,maxiter=100)
         xJAC, = cg(Af,rhs,JAC;tol=tol,maxiter=100)

--- a/test/cg.jl
+++ b/test/cg.jl
@@ -47,7 +47,7 @@ context("Sparse Laplacian") do
         @fact norm(A*xJAC - rhs) --> less_than_or_equal(tol)
     end
 
-    Af = MatrixFcn(A)
+    Af = FuncMatrix(A)
     context("function") do
         xCG, = cg(Af,rhs;tol=tol,maxiter=100)
         xJAC, = cg(Af,rhs,JAC;tol=tol,maxiter=100)

--- a/test/common.jl
+++ b/test/common.jl
@@ -36,7 +36,7 @@ context("Linear operator defined as a function") do
     Atimesb = [b[end]; b[1:end-1]]
     Aptimesb = [b[2:end]; b[1]]
 
-    A = FuncMatrix(5, 5, mul=shiftback!, typ=Int)
+    A = LinearMap(Int, 5, 5, mul=shiftback!)
     @fact eltype(A) --> Int
     @fact size(A) --> (5,5)
     @fact size(A,1) --> 5
@@ -47,7 +47,7 @@ context("Linear operator defined as a function") do
     output = similar(b)
     @fact A_mul_B!(output, A, b) --> Atimesb
 
-    A = FuncMatrix(5, 5, typ=Int, mul=shiftback!, cmul=shiftfwd!)
+    A = LinearMap(Int, 5, 5, mul=shiftback!, cmul=shiftfwd!)
     @fact eltype(A) --> Int
     @fact size(A) --> (5,5)
     @fact size(A,1) --> 5

--- a/test/common.jl
+++ b/test/common.jl
@@ -36,7 +36,7 @@ context("Linear operator defined as a function") do
     Atimesb = [b[end]; b[1:end-1]]
     Aptimesb = [b[2:end]; b[1]]
 
-    A = MatrixFcn{Int}(5, 5, shiftback!)
+    A = FuncMatrix(5, 5, mul=shiftback!, typ=Int)
     @fact eltype(A) --> Int
     @fact size(A) --> (5,5)
     @fact size(A,1) --> 5
@@ -48,7 +48,7 @@ context("Linear operator defined as a function") do
     @fact A_mul_B!(output, A, b) --> Atimesb
     @fact A'*b --> Atimesb
 
-    A = MatrixCFcn{Int}(5, 5, shiftback!, shiftfwd!)
+    A = FuncMatrix(5, 5, typ=Int, mul=shiftback!, cmul=shiftfwd!)
     @fact eltype(A) --> Int
     @fact size(A) --> (5,5)
     @fact size(A,1) --> 5

--- a/test/common.jl
+++ b/test/common.jl
@@ -46,7 +46,6 @@ context("Linear operator defined as a function") do
 
     output = similar(b)
     @fact A_mul_B!(output, A, b) --> Atimesb
-    @fact A'*b --> Atimesb
 
     A = FuncMatrix(5, 5, typ=Int, mul=shiftback!, cmul=shiftfwd!)
     @fact eltype(A) --> Int

--- a/test/lsqr.jl
+++ b/test/lsqr.jl
@@ -20,7 +20,7 @@ context("SOL test") do
     function lsqrSOLtest( m, n, damp )
         fmul  = (out, b) -> Aprodxxx!(out,b,1,m,n)
         fcmul = (out, b) -> Aprodxxx!(out,b,2,m,n)
-        A = FuncMatrix(m, n, mul=fmul, cmul=fcmul, typ=Int)
+        A = LinearMap(Int, m, n, mul=fmul, cmul=fcmul)
         xtrue = n:-1:1
         b = float(A*xtrue)
         x, = lsqr(A, b, atol = 1e-6, btol = 1e-6, conlim = 1e10, maxiter = 10n)

--- a/test/lsqr.jl
+++ b/test/lsqr.jl
@@ -20,7 +20,7 @@ context("SOL test") do
     function lsqrSOLtest( m, n, damp )
         fmul  = (out, b) -> Aprodxxx!(out,b,1,m,n)
         fcmul = (out, b) -> Aprodxxx!(out,b,2,m,n)
-        A = MatrixCFcn{Int}(m, n, fmul, fcmul)
+        A = FuncMatrix(m, n, mul=fmul, cmul=fcmul, typ=Int)
         xtrue = n:-1:1
         b = float(A*xtrue)
         x, = lsqr(A, b, atol = 1e-6, btol = 1e-6, conlim = 1e10, maxiter = 10n)


### PR DESCRIPTION
Replace `AbstractMatrixCFcn` and children for a new unique type `LinearMap`. LinearMap can be created without any functions and defaults them to identity, multiplication and ctranspose multiplication can be added individually. It also switches the functions when it is ctransposed to know at every moment which function to use.

Simpler to use and there is only one type for the user to handle.
