### PR TITLE
Improve ConvergenceHistory

### DIFF
--- a/src/cg.jl
+++ b/src/cg.jl
@@ -21,7 +21,7 @@ function cg_method!(log::ConvergenceHistory, x, K::KrylovSubspace, b, Pl=1;
     p = z = Pl\r
     γ = dot(r, z)
     for iter=1:maxiter
-        nextiter!(log)
+        nextiter!(log, mvps=1)
         append!(K, p)
         q = nextvec(K)
         α = γ/dot(p, q)
@@ -38,7 +38,6 @@ function cg_method!(log::ConvergenceHistory, x, K::KrylovSubspace, b, Pl=1;
         p = z + β*p
     end
     shrink!(log)
-    setmvps(log, K.mvps)
     setconv(log, 0<=norm(r)<tol)
     x
 end

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -3,36 +3,42 @@ export cg, cg!
 cg(A, b, Pl=1; kwargs...) =  cg!(zerox(A,b), A, b, Pl; kwargs...)
 
 function cg!(x, A, b, Pl=1; tol::Real=size(A,2)*eps(), maxiter::Int=size(A,2))
+    history = ConvergenceHistory()
+    history[:tol] = tol
+    reserve!(history,:resnorm, maxiter)
+
     K = KrylovSubspace(A, length(b), 1, Vector{Adivtype(A,b)}[])
     init!(K, x)
-    cg!(x, K, b, Pl; tol=tol, maxiter=maxiter)
+    cg_method!(history, x, K, b, Pl; tol=tol, maxiter=maxiter)
+    x, history
 end
 
-function cg!(x, K::KrylovSubspace, b, Pl=1;
+function cg_method!(log::ConvergenceHistory, x, K::KrylovSubspace, b, Pl=1;
         tol::Real=size(K.A,2)*eps(), maxiter::Integer=size(K.A,2))
-    resnorms = zeros(maxiter)
 
     tol = tol * norm(b)
     r = b - nextvec(K)
     p = z = Pl\r
     γ = dot(r, z)
     for iter=1:maxiter
+        nextiter!(log)
         append!(K, p)
         q = nextvec(K)
         α = γ/dot(p, q)
         # α>=0 || throw(PosSemidefException("α=$α"))
         update!(x, α, p)
         r -= α*q
-        resnorms[iter] = norm(r)
-        if resnorms[iter] < tol #Converged?
-            resnorms = resnorms[1:iter]
-            break
-        end
+        resnorm = norm(r)
+        push!(log,:resnorm,resnorm)
+        resnorm < tol && break
         z = Pl\r
         oldγ = γ
         γ = dot(r, z)
         β = γ/oldγ
         p = z + β*p
-      end
-    x, ConvergenceHistory(0<resnorms[end]<tol, tol, K.mvps, resnorms)
+    end
+    shrink!(log)
+    setmvps(log, K.mvps)
+    setconv(log, 0<=norm(r)<tol)
+    x
 end

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -29,7 +29,7 @@ function chebyshev_method!(
 	d::eltype(b) = (λmax + λmin)/2
 	c::eltype(b) = (λmax - λmin)/2
 	for iter = 1:maxiter
-        nextiter!(log)
+        nextiter!(log, mvps=1)
 		z = Pr\r
 		if iter == 1
 			p = z
@@ -48,7 +48,6 @@ function chebyshev_method!(
         resnorm < tol && break
 	end
     shrink!(log)
-    setmvps(log, K.mvps)
     setconv(log, 0<=norm(r)<tol)
 	x
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -60,7 +60,7 @@ Store general and in-depth information about an iterative method.
 
 * `isconverged::Bool`: convergence of the method.
 * `data::Dict{Symbol,Any}`: Stores all the information stored during the method execution.
-It tolreances, residuals and other information, e.g. ritz values in [svdl](@ref).
+It stores tolerances, residuals and other information, e.g. ritz values in [svdl](@ref).
 
 **Constructors**
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,5 +1,5 @@
 import  Base: eltype, empty!, eps, length, ndims, push!, real, size, *, \,
-        A_mul_B!, Ac_mul_B, Ac_mul_B!
+        A_mul_B!, Ac_mul_B, Ac_mul_B!, getindex, setindex!, push!
 
 export  A_mul_B
 
@@ -46,25 +46,250 @@ _randn!(v::Array{Float64}) = randn!(v)
 _randn!(v) = copy!(v, randn(length(v)))
 
 #### Reporting
-type ConvergenceHistory{T, R}
-    isconverged::Bool
-    threshold::T
+"""
+Store general and in-depth information about an iterative method.
+
+**Fields**
+
+* `mvps::Int`: number of matrix vector products.
+* `mtvps::Int`: number of transposed matrix-vector products
+* `iters::Int`: iterations taken by the method.
+* `restart::T`: restart relevant information.
+    - `T == Int`: iterations per restart.
+    - `T == Void`: methods without restarts.
+
+* `isconverged::Bool`: convergence of the method.
+* `tol::Dict{Symbol, Real}`: tolerances of the method.
+* `data::Dict{Symbol, VecOrMat}`: iteration information of a method. It usually
+contains residuals, but can have other information, e.g. ritz values in [svdl](@ref).
+
+**Constructors**
+
+    ConvergenceHistory()
+    ConvergenceHistory(restart)
+
+Create `ConvergenceHistory` with empty fields.
+
+**Arguments**
+
+* `restart`: number of iterations per restart.
+
+**Plots**
+
+Supports plots using the `Plots.jl` package via a type recipe. Vectors are
+ploted as series and matrices as scatterplots.
+
+**Implements**
+
+* `Base`: `getindex`, `setindex!`, `push!`
+
+"""
+type ConvergenceHistory{T,K}
     mvps::Int
-    residuals::R
+    mtvps::Int
+    iters::Int
+    restart::K
+    isconverged::Bool
+    tol::Dict{Symbol, Real}
+    data::Dict{Symbol, VecOrMat}
+end
+function ConvergenceHistory(;restart=nothing, partial=true)
+    ConvergenceHistory{!partial,typeof(restart)}(0,0,0,restart,false,
+        Dict{Symbol, Real}(), Dict{Symbol, VecOrMat}()
+        )
 end
 
-function empty!(ch::ConvergenceHistory)
-    ch.isconverged = false
-    ch.mvps = 0
-    empty!(ch.residuals)
-    ch
+"""
+Stores information of the current iteration.
+"""
+typealias PartialHistory ConvergenceHistory{false}
+
+"""
+Stores the information of all the iterations.
+"""
+typealias CompleteHistory ConvergenceHistory{true}
+
+"""
+History without resets.
+"""
+typealias UnrestartedHistory{T} ConvergenceHistory{T, Void}
+
+"""
+History with resets.
+"""
+typealias RestartedHistory{T} ConvergenceHistory{T, Int}
+
+"""
+    getindex(ch, s)
+
+Get collection or tolerance associated with key `s` in `ch::ConvergenceHistory`.
+
+    getindex(ch, s, kwargs...)
+
+Access elements of the collection associated with key `s` in `ch::ConvergenceHistory`.
+"""
+function getindex(ch::PartialHistory, s::Symbol)
+    if haskey(ch.tol, s)
+        ch.tol[s]
+    else
+        ch.data[s][1]
+    end
+end
+function getindex(ch::CompleteHistory, s::Symbol)
+    if haskey(ch.tol, s)
+        ch.tol[s]
+    else
+        ch.data[s]
+    end
+end
+getindex(ch::CompleteHistory, s::Symbol, kwargs...) = ch.data[s][kwargs...]
+
+"""
+    setindex!(ch, tol, s)
+
+Set tolerance value associated with `s` in `ch::ConvergenceHistory` to `tol`.
+
+    setindex!(ch, val, s, kwargs...)
+
+Set collection element associated with key `s` in `ch::ConvergenceHistory` to val.
+"""
+setindex!(ch::ConvergenceHistory, val::Real, s::Symbol) = ch.tol[s] = val
+setindex!(ch::CompleteHistory, val, s::Symbol, kwargs...) = ch.data[s][kwargs...] = val
+
+"""
+    push!(ch, key, val)
+
+Push contents of `val` to collection associated with `key` in `ch::ConvergenceHistory`.
+"""
+function push!(ch::ConvergenceHistory, key::Symbol, vec::Union{Vector,Tuple})
+    matrix = ch.data[key]
+    width = size(matrix,2)
+    iter = isa(ch,CompleteHistory) ? ch.iters : 1
+    base = (iter-1)*width
+    for i in 1:min(width,length(vec))
+        matrix[base+i] = vec[i]
+    end
+end
+push!(ch::ConvergenceHistory, key::Symbol, vec) = push_custom_data!(ch, key, vec)
+
+push_custom_data!(ch::PartialHistory, key::Symbol, val) = ch.data[key][1] = val
+push_custom_data!(ch::CompleteHistory, key::Symbol, val) = ch.data[key][ch.iters] = val
+
+"""
+    reserve!(ch, key, maxiter)
+    reserve!(typ, key, maxiter)
+    reserve!(ch, key, maxiter, size)
+    reserve!(typ, ch, key, maxiter, size)
+
+Reserve space for per iteration data in `ch`. If size is provided, intead of a
+vector it will reserve matrix of dimensions `(maxiter, size)`.
+
+**Arguments**
+
+* `typ::Type`: Type of the elements to store. Defaults to `Float64` when not given.
+* `ch::ConvergenceHistory`: convergence history.
+* `key::Symbol`: key used to identify the data.
+* `maxiter::Int`: number of iterations to save space for.
+* `size::Int`: number of elements to store with the `key` identifier.
+
+"""
+function reserve!(ch::ConvergenceHistory, key::Symbol, maxiter::Int, kwargs...)
+    len = isa(ch,CompleteHistory) ? maxiter : 1
+    _reserve!(Float64, ch, key, len, kwargs...)
+end
+function reserve!(typ::Type, ch::ConvergenceHistory, key::Symbol, maxiter::Int, kwargs...)
+    len = isa(ch,CompleteHistory) ? maxiter : 1
+    _reserve!(typ, ch, key, len, kwargs...)
 end
 
-function push!(ch::ConvergenceHistory, resnorm::Number)
-    push!(ch.residuals, resnorm)
-    ch
+function _reserve!(typ::Type, ch::ConvergenceHistory, key::Symbol, len::Int)
+    ch.data[key] = Vector{typ}(len)
 end
-push!(ch::ConvergenceHistory, residual::AbstractVector) = push!(ch, norm(residual))
+function _reserve!(typ::Type, ch::ConvergenceHistory, key::Symbol, len::Int, size::Int)
+    ch.data[key] = Matrix{typ}(len,size)
+end
+
+"""
+    shrink!(ml)
+
+shrinks the reserved space for `MethodLog` `ch` to the space actually used to log.
+"""
+shrink!(::PartialHistory) = nothing
+function shrink!(ch::CompleteHistory)
+    for key in datakeys(ch)
+        elem = ch.data[key]
+        if isa(elem, Vector)
+            resize!(elem, ch.iters)
+        elseif isa(elem, Matrix)
+            ch.data[key] = elem[1:ch.iters, :]
+        end
+    end
+end
+
+"""
+    nprods(ch)
+
+Number of matrix-vector products plus transposed matrix-vector products
+logged in `ConvergenceHistory` `ch`.
+"""
+nprods(ch::ConvergenceHistory) = ch.mvps+ch.mtvps
+
+"""
+    niters(ch)
+
+Number of iterations logged in `ConvergenceHistory` `ch`.
+"""
+niters(ch::ConvergenceHistory) = ch.iters
+
+"""
+    nrests(ch)
+
+Number of restarts logged in `ConvergenceHistory` `ch`.
+"""
+nrests(ch::RestartedHistory) = Int(ceil(ch.iters/ch.restart))
+
+"""
+    tolkeys(ch)
+
+Key iterator of the tolerances logged in `ConvergenceHistory` `ch`.
+"""
+tolkeys(ch::ConvergenceHistory) = keys(ch.tol)
+
+"""
+    datakeys(ch)
+
+Key iterator of the per iteration data logged in `ConvergenceHistory` `ch`.
+"""
+datakeys(ch::ConvergenceHistory) = keys(ch.data)
+
+"""
+    setmvps(ml, val)
+
+Set `val` as number of matrix-vector products in [`MethodLog`](@ref) `ch`.
+"""
+setmvps(ch::ConvergenceHistory, val::Int) = ch.mvps=val
+
+"""
+    setmtvps(ml, val)
+
+Set `val` as number of transposed matrix-vector products in [`MethodLog`](@ref) `ch`.
+"""
+setmtvps(ch::ConvergenceHistory, val::Int) = ch.mtvps=val
+
+"""
+    setconv(ml, val)
+
+Set `val` as convergence status of the method in [`MethodLog`](@ref) ch.
+"""
+setconv(ch::ConvergenceHistory, val::Bool) = ch.isconverged=val
+
+"""
+    nextiter!(ml)
+
+Adds one the the number of iterations in [`MethodLog`](@ref) `ch`. This is
+necessary to avoid overwriting information with `push!(ml)`.
+"""
+nextiter!(ch::ConvergenceHistory) = ch.iters+=1
 
 #### Errors
 export PosSemidefException

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -85,7 +85,6 @@ function gmres_method!(log::ConvergenceHistory, x, A, b, Pl=1, Pr=1;
     s = zeros(T,restart+1)         #Residual history
     J = zeros(T,restart,3)         #Givens rotation values
     tol = tol * norm(Pl\b)         #Relative tolerance
-    isconverged = false
     matvecs = 0
     K = KrylovSubspace(x->Pl\(A*(Pr\x)), n, restart+1, T)
     for iter = 1:maxiter
@@ -95,7 +94,7 @@ function gmres_method!(log::ConvergenceHistory, x, A, b, Pl=1, Pr=1;
 
         N = restart
         for j = 1:restart
-            nextiter!(log)
+            nextiter!(log, mvps=1)
             #Calculate next orthonormal basis vector in the Krylov subspace
             H[1:j+1, j] = arnoldi!(K, w)
 
@@ -127,14 +126,10 @@ function gmres_method!(log::ConvergenceHistory, x, A, b, Pl=1, Pr=1;
         update!(x, 1, Pr\w) #Right preconditioner
 
         if rho < tol
-            isconverged = true
-            matvecs = (iter-1)*restart + N
+            setconv(log, true)
             break
         end
     end
     shrink!(log)
-    setconv(log, isconverged)
-    setmvps(log, matvecs)
-
     x
 end

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -44,6 +44,16 @@ gmres(A, b, Pl=1, Pr=1;
 
 function gmres!(x, A, b, Pl=1, Pr=1;
         tol=sqrt(eps(typeof(real(b[1])))), maxiter::Int=1, restart::Int=min(20,length(b)))
+
+    history = ConvergenceHistory(restart=restart)
+    history[:tol] = tol
+    reserve!(history,:resnorm, maxiter)
+    gmres_method!(history, x, A, b, Pl, Pr; tol=tol, maxiter=maxiter, restart=restart)
+    x, history
+end
+
+function gmres_method!(log::ConvergenceHistory, x, A, b, Pl=1, Pr=1;
+        tol=sqrt(eps(typeof(real(b[1])))), maxiter::Int=1, restart::Int=min(20,length(b)))
 #Generalized Minimum RESidual
 #Reference: http://www.netlib.org/templates/templates.pdf
 #           2.3.4 Generalized Minimal Residual (GMRES)
@@ -75,7 +85,6 @@ function gmres!(x, A, b, Pl=1, Pr=1;
     s = zeros(T,restart+1)         #Residual history
     J = zeros(T,restart,3)         #Givens rotation values
     tol = tol * norm(Pl\b)         #Relative tolerance
-    resnorms = zeros(typeof(real(b[1])), maxiter, restart)
     isconverged = false
     matvecs = 0
     K = KrylovSubspace(x->Pl\(A*(Pr\x)), n, restart+1, T)
@@ -86,6 +95,7 @@ function gmres!(x, A, b, Pl=1, Pr=1;
 
         N = restart
         for j = 1:restart
+            nextiter!(log)
             #Calculate next orthonormal basis vector in the Krylov subspace
             H[1:j+1, j] = arnoldi!(K, w)
 
@@ -104,7 +114,8 @@ function gmres!(x, A, b, Pl=1, Pr=1;
             #-conj(G.s) * s[j]
             s[j]  *= J[j,1] #G.c
 
-            resnorms[iter, j] = rho = abs(s[j+1])
+            rho = abs(s[j+1])
+            push!(log, :resnorm, rho)
             if rho < tol
                 N = j
                 break
@@ -116,12 +127,14 @@ function gmres!(x, A, b, Pl=1, Pr=1;
         update!(x, 1, Pr\w) #Right preconditioner
 
         if rho < tol
-            resnorms = resnorms[1:iter, :]
             isconverged = true
             matvecs = (iter-1)*restart + N
             break
         end
     end
+    shrink!(log)
+    setconv(log, isconverged)
+    setmvps(log, matvecs)
 
-    return x, ConvergenceHistory(isconverged, tol, matvecs, resnorms)
+    x
 end

--- a/src/idrs.jl
+++ b/src/idrs.jl
@@ -122,7 +122,7 @@ function idrs_method!{T}(log::ConvergenceHistory, X, op, args, C::T,
             f[i] = vecdot(P[i], R)
         end
         for k in 1:s
-            nextiter!(log)
+            nextiter!(log,mvps=1)
 
             # Solve small system and make v orthogonal to P
 
@@ -185,7 +185,6 @@ function idrs_method!{T}(log::ConvergenceHistory, X, op, args, C::T,
             iter += 1
             if normR < tol || iter > maxiter
                 shrink!(log)
-                setmvps(log, iter-1)
                 setconv(log, 0<=normR<tol)
                 return X
             end
@@ -218,7 +217,7 @@ function idrs_method!{T}(log::ConvergenceHistory, X, op, args, C::T,
             normR = vecnorm(R_s)
         end
         iter += 1
-        nextiter!(log)
+        nextiter!(log,mvps=1)
         push!(log, :resnorm, normR)
     end
     if smoothing
@@ -226,6 +225,5 @@ function idrs_method!{T}(log::ConvergenceHistory, X, op, args, C::T,
     end
     shrink!(log)
     setconv(log, 0<=normR<tol)
-    setmvps(log, iter)
     X
 end

--- a/src/idrs.jl
+++ b/src/idrs.jl
@@ -77,17 +77,21 @@ References
     [4] IDR(s)' webpage http://ta.twi.tudelft.nl/nw/users/gijzen/IDR.html
 """
 idrs(A, b; s = 8, tol=sqrt(eps(typeof(real(b[1])))), maxiter = length(b)^2, smoothing=false) =
-    idrs_core!(zerox(A, b), linsys_op, (A,), b, s, tol, maxiter; smoothing=smoothing)
+    idrs!(zerox(A, b), A, b; s=s, tol=tol, maxiter=maxiter, smoothing=smoothing)
 
-idrs!(x, A, b; s = 8, tol=sqrt(eps(typeof(real(b[1])))), maxiter=length(x)^2, smoothing=false) =
-    idrs_core!(x, linsys_op, (A,), b, s, tol, maxiter; smoothing=smoothing)
+function idrs!(x, A, b; s = 8, tol=sqrt(eps(typeof(real(b[1])))), maxiter=length(x)^2, smoothing=false)
+    history = ConvergenceHistory()
+    history[:tol] = tol
+    reserve!(history,:resnorm, maxiter)
+    idrs_method!(history, x, linsys_op, (A,), b, s, tol, maxiter; smoothing=smoothing)
+    x, history
+end
 
-function idrs_core!{T}(X, op, args, C::T,
+function idrs_method!{T}(log::ConvergenceHistory, X, op, args, C::T,
     s::Number, tol::Number, maxiter::Number; smoothing::Bool=false)
 
     R = C - op(X, args...)::T
     normR = vecnorm(R)
-    res = typeof(tol)[normR]
 	iter = 0
 
     if smoothing
@@ -118,6 +122,7 @@ function idrs_core!{T}(X, op, args, C::T,
             f[i] = vecdot(P[i], R)
         end
         for k in 1:s
+            nextiter!(log)
 
             # Solve small system and make v orthogonal to P
 
@@ -176,10 +181,13 @@ function idrs_core!{T}(X, op, args, C::T,
 
                 normR = vecnorm(R_s)
             end
-            res = [res; normR]
+            push!(log, :resnorm, normR)
             iter += 1
             if normR < tol || iter > maxiter
-                return X, ConvergenceHistory(normR < tol, tol, length(res), res)
+                shrink!(log)
+                setmvps(log, iter-1)
+                setconv(log, 0<=normR<tol)
+                return X
             end
             if k < s
                 f[k+1:s] = f[k+1:s] - beta*M[k+1:s,k]
@@ -210,11 +218,14 @@ function idrs_core!{T}(X, op, args, C::T,
             normR = vecnorm(R_s)
         end
         iter += 1
-        res = [res; normR]
+        nextiter!(log)
+        push!(log, :resnorm, normR)
     end
     if smoothing
         copy!(X, X_s)
     end
-    return X, ConvergenceHistory(res[end]<tol, tol, length(res), res)
+    shrink!(log)
+    setconv(log, 0<=normR<tol)
+    setmvps(log, iter)
+    X
 end
-

--- a/src/lanczos.jl
+++ b/src/lanczos.jl
@@ -31,13 +31,12 @@ function eiglancz_method!(log::ConvergenceHistory, A, neigs::Int=size(A,1); tol:
     initrand!(K)
     e1 = eigvals(lanczos!(K), 1:neigs)
     for iter=1:maxiter
-        nextiter!(log)
+        nextiter!(log,mvps=1)
         e0, e1 = e1, eigvals(lanczos!(K), 1:neigs)
         resnorm = norm(e1-e0)
         push!(log, :resnorm, resnorm)
         resnorm < tol && (setconv(log, resnorm>=0); break)
     end
     shrink!(log)
-    setmvps(log, K.mvps)
     e1
 end

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -102,13 +102,17 @@ function lsmr_method!(log::ConvergenceHistory, x, A, b, v, h, hbar;
     normAr = α * β
     iter = 0
     # Exit if b = 0 or A'b = 0.
+
+    log.mvps=1
+    log.mtvps=1
     if normAr != 0
         while iter < maxiter
-            nextiter!(log,mvps=2)
+            nextiter!(log,mvps=1)
             iter += 1
             A_mul_B!(1, A, v, -α, u)
             β = norm(u)
             if β > 0
+                log.mtvps+=1
                 scale!(u, inv(β))
                 Ac_mul_B!(1, A, u, -β, v)
                 α = norm(v)

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -39,7 +39,7 @@ using Base.LinAlg
 ## x is initial x0. Transformed in place to the solution.
 ## b equals initial b. Transformed in place
 ## v, h, hbar are storage arrays of length size(A, 2)
-function lsmr!(x, A, b, v, h, hbar;
+function lsmr_method!(log::ConvergenceHistory, x, A, b, v, h, hbar;
     atol::Number = 1e-6, btol::Number = 1e-6, conlim::Number = 1e8,
     maxiter::Integer = max(size(A,1), size(A,2)), λ::Number = 0)
 
@@ -64,6 +64,10 @@ function lsmr!(x, A, b, v, h, hbar;
     Ac_mul_B!(1, A, u, 0, v)
     α = norm(v)
     α > 0 && scale!(v, inv(α))
+
+    log[:atol] = atol
+    log[:btol] = btol
+    log[:ctol] = ctol
 
     # Initialize variables for 1st iteration.
     ζbar = α * β
@@ -96,11 +100,11 @@ function lsmr!(x, A, b, v, h, hbar;
     istop = 0
     normr = β
     normAr = α * β
-    tests = Tuple{Tr, Tr, Tr}[]
     iter = 0
     # Exit if b = 0 or A'b = 0.
     if normAr != 0
         while iter < maxiter
+            nextiter!(log)
             iter += 1
             A_mul_B!(1, A, v, -α, u)
             β = norm(u)
@@ -197,7 +201,9 @@ function lsmr!(x, A, b, v, h, hbar;
             test1 = normr / normb
             test2 = normAr / (normA * normr)
             test3 = inv(condA)
-            push!(tests, (test1, test2, test3))
+            push!(log, :cnorm, test3)
+            push!(log, :anorm, test2)
+            push!(log, :rnorm, test1)
 
             t1 = test1 / (one(Tr) + normA * normx / normb)
             rtol = btol + atol * normA * normx / normb
@@ -216,21 +222,27 @@ function lsmr!(x, A, b, v, h, hbar;
             if test1 <= rtol  istop = 1; break end
         end
     end
-    converged = istop ∉ (3, 6, 7)
-    tol = (atol, btol, ctol)
-    ch = ConvergenceHistory(converged, tol, 2 * iter, tests)
-    return x, ch
+    shrink!(log)
+    setmvps(log, 2*iter)
+    setconv(log, istop ∉ (3, 6, 7))
+    x
 end
 
 ## Arguments:
 ## x is initial x0. Transformed in place to the solution.
-function lsmr!(x, A, b; kwargs...)
+function lsmr!(x, A, b; maxiter::Integer = max(size(A,1)), kwargs...)
+    history = ConvergenceHistory()
+    reserve!(history,:anorm,maxiter)
+    reserve!(history,:rnorm,maxiter)
+    reserve!(history,:cnorm,maxiter)
+
     T = Adivtype(A, b)
     m, n = size(A, 1), size(A, 2)
     btmp = similar(b, T)
     copy!(btmp, b)
     v, h, hbar = similar(x, T), similar(x, T), similar(x, T)
-    lsmr!(x, A, btmp, v, h, hbar; kwargs...)
+    lsmr_method!(history, x, A, btmp, v, h, hbar; maxiter=maxiter, kwargs...)
+    x, history
 end
 
 function lsmr(A, b; kwargs...)
@@ -244,4 +256,3 @@ for (name, symbol) in ((:Ac_mul_B!, 'T'), (:A_mul_B!, 'N'))
         end
     end
 end
-

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -104,7 +104,7 @@ function lsmr_method!(log::ConvergenceHistory, x, A, b, v, h, hbar;
     # Exit if b = 0 or A'b = 0.
     if normAr != 0
         while iter < maxiter
-            nextiter!(log)
+            nextiter!(log,mvps=2)
             iter += 1
             A_mul_B!(1, A, v, -α, u)
             β = norm(u)
@@ -223,7 +223,6 @@ function lsmr_method!(log::ConvergenceHistory, x, A, b, v, h, hbar;
         end
     end
     shrink!(log)
-    setmvps(log, 2*iter)
     setconv(log, istop ∉ (3, 6, 7))
     x
 end
@@ -232,9 +231,7 @@ end
 ## x is initial x0. Transformed in place to the solution.
 function lsmr!(x, A, b; maxiter::Integer = max(size(A,1)), kwargs...)
     history = ConvergenceHistory()
-    reserve!(history,:anorm,maxiter)
-    reserve!(history,:rnorm,maxiter)
-    reserve!(history,:cnorm,maxiter)
+    reserve!(history,[:anorm,:rnorm,:cnorm],maxiter)
 
     T = Adivtype(A, b)
     m, n = size(A, 1), size(A, 2)

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -94,7 +94,7 @@ function lsqr_method!(log::ConvergenceHistory, x, A, b; damp=0, atol=sqrt(eps(Ad
     #     Main iteration loop.
     #------------------------------------------------------------------
     while itn < maxiter
-        nextiter!(log)
+        nextiter!(log,mvps=2)
         itn += 1
 
         # Perform the next step of the bidiagonalization to obtain the
@@ -215,7 +215,6 @@ function lsqr_method!(log::ConvergenceHistory, x, A, b; damp=0, atol=sqrt(eps(Ad
         if  test1 <= rtol  istop = 1; end
     end
     shrink!(log)
-    setmvps(log, 2*itn+2)
     setconv(log, istop > 0)
     x
 end
@@ -224,10 +223,7 @@ function lsqr!(x, A, b; maxiter::Int=max(size(A,1), size(A,2)), kwargs...)
     T = Adivtype(A, b)
     z = zero(T)
     history = ConvergenceHistory()
-    reserve!(history,:resnorm,maxiter)
-    reserve!(history,:anorm,maxiter)
-    reserve!(history,:rnorm,maxiter)
-    reserve!(history,:cnorm,maxiter)
+    reserve!(history,[:resnorm,:anorm,:rnorm,:cnorm],maxiter)
     lsqr_method!(history, x, A, b; maxiter=maxiter, kwargs...)
     x, history
 end

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -72,6 +72,7 @@ function lsqr_method!(log::ConvergenceHistory, x, A, b; damp=0, atol=sqrt(eps(Ad
     beta = norm(u)
     alpha = zero(Tr)
     if beta > 0
+        log.mtvps=1
         scale!(u, inv(beta))
         Ac_mul_B!(v,A,u)
         alpha = norm(v)
@@ -94,7 +95,7 @@ function lsqr_method!(log::ConvergenceHistory, x, A, b; damp=0, atol=sqrt(eps(Ad
     #     Main iteration loop.
     #------------------------------------------------------------------
     while itn < maxiter
-        nextiter!(log,mvps=2)
+        nextiter!(log,mvps=1)
         itn += 1
 
         # Perform the next step of the bidiagonalization to obtain the
@@ -109,6 +110,7 @@ function lsqr_method!(log::ConvergenceHistory, x, A, b; damp=0, atol=sqrt(eps(Ad
         LinAlg.axpy!(one(eltype(tmpm)), tmpm, u)
         beta = norm(u)
         if beta > 0
+            log.mtvps+=1
             scale!(u, inv(beta))
             Anorm = sqrt(abs2(Anorm) + abs2(alpha) + abs2(beta) + dampsq)
             # Note that the following three lines are a band aid for a GEMM: X: C := αA'B + βC.

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -9,7 +9,7 @@ function powm_method!{T}(log::ConvergenceHistory, K::KrylovSubspace{T};
     θ = zero(T)
     v = Array(T, K.n)
     for iter=1:maxiter
-        nextiter!(log)
+        nextiter!(log,mvps=1)
         v = lastvec(K)
         y = nextvec(K)
         θ = dot(v, y)
@@ -18,8 +18,6 @@ function powm_method!{T}(log::ConvergenceHistory, K::KrylovSubspace{T};
         resnorm <= tol*abs(θ) && (setconv(log, resnorm >= 0); break)
         appendunit!(K, y)
     end
-    shrink!(log)
-    setmvps(log, K.mvps)
     Eigenpair(θ, v)
 end
 
@@ -47,7 +45,7 @@ function invpowm_method!{T}(log::ConvergenceHistory, K::KrylovSubspace{T}, σ::N
     y = Array(T, K.n)
     σ = convert(T, σ)
     for iter=1:maxiter
-        nextiter!(log)
+        nextiter!(log,mvps=1)
         v = lastvec(K)
         y = (K.A-σ*eye(K))\v
         θ = dot(v, y)
@@ -57,7 +55,6 @@ function invpowm_method!{T}(log::ConvergenceHistory, K::KrylovSubspace{T}, σ::N
         appendunit!(K, y)
     end
     shrink!(log)
-    setmvps(log, K.mvps)
     Eigenpair(σ+1/θ, y/θ)
 end
 
@@ -82,7 +79,7 @@ function rqi_method!{T}(log::ConvergenceHistory, K::KrylovSubspace{T}, σ::Numbe
     v = lastvec(K)
     ρ = dot(v, nextvec(K))
     for iter=1:maxiter
-        nextiter!(log)
+        nextiter!(log,mvps=1)
         y = (K.A-ρ*eye(K))\v
         θ = norm(y)
         ρ += dot(y,v)/θ^2
@@ -92,7 +89,6 @@ function rqi_method!{T}(log::ConvergenceHistory, K::KrylovSubspace{T}, σ::Numbe
         θ >= 1/tol && (setconv(log, resnorm >= 0); break)
     end
     shrink!(history)
-    setmvps(log, K.mvps)
     Eigenpair(ρ, v)
 end
 

--- a/src/stationary.jl
+++ b/src/stationary.jl
@@ -23,7 +23,7 @@ function jacobi_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b;
     z = zero(Amultype(A, x))
     tol = tol * norm(b)
 	for iter=1:maxiter
-        nextiter!(log)
+        nextiter!(log,mvps=1)
 		for i=1:n
 			xi = z
 			for j=[1:i-1;i+1:n]
@@ -39,7 +39,6 @@ function jacobi_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b;
 		copy!(xold, x)
 	end
     shrink!(log)
-    setmvps(log, iter)
 	x
 end
 
@@ -64,7 +63,7 @@ function gauss_seidel_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b;
     z = zero(Amultype(A, x))
     tol = tol * norm(b)
 	for iter=1:maxiter
-        nextiter!(log)
+        nextiter!(log,mvps=1)
 		for i=1:n
 			σ=z
 			for j=1:i-1
@@ -83,7 +82,6 @@ function gauss_seidel_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b;
 		copy!(xold, x)
 	end
     shrink!(log)
-    setmvps(log, iter)
 	x
 end
 
@@ -111,7 +109,7 @@ function sor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real;
     z = zero(Amultype(A, x))
     tol = tol * norm(b)
 	for iter=1:maxiter
-        nextiter!(log)
+        nextiter!(log,mvps=1)
 		for i=1:n
 			σ=z
 			for j=1:i-1
@@ -131,7 +129,6 @@ function sor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real;
 		copy!(xold, x)
 	end
     shrink!(log)
-    setmvps(log, iter)
 	x
 end
 
@@ -160,7 +157,7 @@ function ssor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real
     z = zero(Amultype(A, x))
     tol = tol * norm(b)
 	for iter=1:maxiter
-        nextiter!(log)
+        nextiter!(log,mvps=1)
 		for i=1:n #Do a SOR sweep
 			σ=z
 			for j=1:i-1
@@ -193,6 +190,5 @@ function ssor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real
 		copy!(xold, x)
 	end
     shrink!(log)
-    setmvps(log, iter)
 	x
 end

--- a/src/svdl.jl
+++ b/src/svdl.jl
@@ -195,8 +195,7 @@ function svdl(A, l::Int=min(6, size(A,1)); tol::Real=√eps(), k::Int=2l,
     history = ConvergenceHistory()
     history[:tol] = tol
     reserve!(BitArray, history,:conv, maxiter)
-    reserve!(history,:ritz, maxiter, l)
-    reserve!(history,:resnorm, maxiter, l)
+    reserve!(history,[:ritz,:resnorm], maxiter, l)
     Bs_type = (method == :ritz) ? BrokenArrowBidiagonal : UpperTriangular
     reserve!(Bs_type, history,:Bs, maxiter)
     reserve!(history,:betas, maxiter)
@@ -257,7 +256,6 @@ function svdl_method!(log::ConvergenceHistory, A, l::Int=min(6, size(A,1)); k::I
         all(conv) && (setconv(log, true); break)
     end
     shrink!(log)
-    setmvps(log, iter)
 
     #Compute singular vectors as necessary and return them in the output
     values = F[:S][1:l]

--- a/test/cg.jl
+++ b/test/cg.jl
@@ -18,12 +18,12 @@ context("Small full system") do
 
     # If you start from the exact solution, you should converge immediately
     x2,ch2 = cg!(A\rhs, A, rhs; tol=tol*10)
-    @fact length(ch2.residuals) --> less_than_or_equal(1)
+    @fact length(ch2[:resnorm]) --> less_than_or_equal(1)
 
     # Test with cholfact should converge immediately
     F = cholfact(A)
     x2,ch2 = cg(A, rhs, F)
-    @fact length(ch2.residuals) --> less_than_or_equal(2)
+    @fact length(ch2[:resnorm]) --> less_than_or_equal(2)
 end
 
 context("Sparse Laplacian") do
@@ -67,9 +67,9 @@ context("Sparse Laplacian") do
         @fact norm(A*xSGS - rhs) --> less_than_or_equal(tol)
         @fact norm(A*xJAC - rhs) --> less_than_or_equal(tol)
 
-        iterCG = length(hCG.residuals)
-        iterJAC = length(hJAC.residuals)
-        iterSGS = length(hSGS.residuals)
+        iterCG = length(hCG[:resnorm])
+        iterJAC = length(hJAC[:resnorm])
+        iterSGS = length(hSGS[:resnorm])
         @fact iterJAC --> iterCG
         @fact iterSGS --> less_than_or_equal(iterJAC) "Preconditioner increased the number of iterations"
     end

--- a/test/lsqr.jl
+++ b/test/lsqr.jl
@@ -83,8 +83,7 @@ context("Issue 64") do
     resnorm = norm(A*x - b)
     @fact resnorm --> less_than(√eps())
     @fact ch.isconverged --> true
-    @fact ch.residuals[end] --> roughly(resnorm, atol=√eps())
+    @fact last(ch[:resnorm]) --> roughly(resnorm, atol=√eps())
 end
 
 end
-

--- a/test/svdl.jl
+++ b/test/svdl.jl
@@ -67,7 +67,7 @@ facts("BrokenArrowBidiagonal") do
     @fact B[3,3] --> 3
     @fact B[2,3] --> 2
     @fact B[3,2] --> 0
-    @fact B[1,3] --> 1 
+    @fact B[1,3] --> 1
     @fact size(B) --> (3,3)
     @fact_throws ArgumentError size(B,3)
     @fact_throws BoundsError B[1,5]


### PR DESCRIPTION
Workarounds had to be made to store information in `ConvergenceHistory`, now it looks like this:

```julia
type ConvergenceHistory{T,K}
    mvps::Int #number of matvecs
    mtvps::Int #number of transposed matvecs
    iters::Int #number of total iters
    restart::K #maximum number of iterations per restart
    isconverged::Bool #convergence flag
    tol::Dict{Symbol, Real} #tolerances
    data::Dict{Symbol, VecOrMat} #Extra data
end
```

Every tolerance and extra data has a key and will be now easier to store, access and plot. Extra information was added too.