### PR TITLE
Add recipe for ConvergenceHistory and some tests

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.5-
 
 UnicodePlots
+RecipesBase

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,5 @@
 FactCheck
 MAT
 MatrixMarket
+Plots
+UnicodePlots

--- a/test/history.jl
+++ b/test/history.jl
@@ -1,0 +1,38 @@
+using IterativeSolvers
+using FactCheck
+using Plots
+
+unicodeplots() 	#Use UnicodePlots backend because it is the lightest
+
+facts("ConvergenceHistory") do
+    #Just check it doesn't crash
+    context("Recipe") do
+        A = lu(rand(10, 10))[1]
+        b = rand(10)
+
+        for solver in [cg, gmres, lsqr, lsmr, idrs, jacobi, gauss_seidel]
+            plot(solver(A,b; log=true)[2])
+            @fact true --> true
+        end
+
+        for solver in [sor, ssor]
+            plot(solver(A,b,1; log=true)[2])
+            @fact true --> true
+        end
+
+        plot(chebyshev(A,b,1,2; log=true)[2])
+        @fact true --> true
+
+        plot(powm(A; log=true)[2])
+        @fact true --> true
+
+        plot(invpowm(A; log=true)[2])
+        @fact true --> true
+
+		plot(rqi(A; log=true)[2])
+        @fact true --> true
+
+        plot(svdl(A; log=true)[3])
+        @fact true --> true
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -284,6 +284,8 @@ include("rlinalg.jl")
 include("rsvd.jl")
 include("rsvd_fnkz.jl")
 
+include("history.jl")
+
 #Expensive tests - don't run by default
 #include("matrixmarket.jl")
 #include("matrixcollection.jl")


### PR DESCRIPTION
Add two recipes for `ConvergenceHistory`, `plot(::ConvergenceHistory)` will plot every field that is a vector or matrix. Vector will be plotted as a series and Matrices as scatterplots. If there is no plotable data , nothing will be done.

There's a second recipe `plot(::ConvergenceHistory,key::Symbol)` to plot a single element inside the data fieldname. If the element isn't a vector or matrix an error will pop up.

If the method has restarts a vertical separator will be added between each restart.

The tests added only check the plots don't crash. Currently `UnicodePlots.jl` outputs some UTF8 warnings on julia 0.5.
