### PR TITLE
New API

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,3 @@
 julia 0.5-
+
+UnicodePlots

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -1,21 +1,34 @@
 export cg, cg!
 
-cg(A, b, Pl=1; kwargs...) =  cg!(zerox(A,b), A, b, Pl; kwargs...)
+####################
+# API method calls #
+####################
 
-function cg!(x, A, b, Pl=1; tol::Real=size(A,2)*eps(), maxiter::Int=size(A,2))
-    history = ConvergenceHistory()
-    history[:tol] = tol
-    reserve!(history,:resnorm, maxiter)
+cg(A, b; kwargs...) = cg!(zerox(A,b), A, b; kwargs...)
 
+function cg!(x, A, b;
+    tol::Real=size(A,2)*eps(), maxiter::Integer=size(A,2),
+    plot=false, log::Bool=false, kwargs...
+    )
+    (plot & !log) && error("Can't plot when log keyword is false")
     K = KrylovSubspace(A, length(b), 1, Vector{Adivtype(A,b)}[])
     init!(K, x)
-    cg_method!(history, x, K, b, Pl; tol=tol, maxiter=maxiter)
-    x, history
+    history = ConvergenceHistory(partial=!log)
+    history[:tol] = tol
+    reserve!(history,:resnorm, maxiter)
+    cg_method!(history, x, K, b; tol=tol, maxiter=maxiter, kwargs...)
+    plot && (shrink!(history); showplot(history))
+    log ? (x, history) : x
 end
 
-function cg_method!(log::ConvergenceHistory, x, K::KrylovSubspace, b, Pl=1;
-        tol::Real=size(K.A,2)*eps(), maxiter::Integer=size(K.A,2))
+#########################
+# Method Implementation #
+#########################
 
+function cg_method!(log::ConvergenceHistory, x, K, b;
+    Pl=1,tol::Real=size(K.A,2)*eps(),maxiter::Integer=size(K.A,2), verbose::Bool=false
+    )
+    verbose && @printf("=== cg ===\n%4s\t%7s\n","iter","resnorm")
     tol = tol * norm(b)
     r = b - nextvec(K)
     p = z = Pl\r
@@ -30,6 +43,7 @@ function cg_method!(log::ConvergenceHistory, x, K::KrylovSubspace, b, Pl=1;
         r -= α*q
         resnorm = norm(r)
         push!(log,:resnorm,resnorm)
+        verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         resnorm < tol && break
         z = Pl\r
         oldγ = γ
@@ -37,7 +51,81 @@ function cg_method!(log::ConvergenceHistory, x, K::KrylovSubspace, b, Pl=1;
         β = γ/oldγ
         p = z + β*p
     end
-    shrink!(log)
+    verbose && @printf("\n")
     setconv(log, 0<=norm(r)<tol)
     x
+end
+
+#################
+# Documentation #
+#################
+
+let
+#Initialize parameters
+doc_call = """    cg(A, b)
+"""
+doc!_call = """    cg!(x, A, b)
+"""
+
+doc_msg = "Solve A*x=b with the conjugate gradients method."
+doc!_msg = "Overwrite `x`.\n\n" * doc_msg
+
+doc_arg = ""
+doc!_arg = """* `x`: initial guess, overwrite final estimation."""
+
+doc_version = (doc_call, doc_msg, doc_arg)
+doc!_version = (doc!_call, doc!_msg, doc!_arg)
+
+i = 0
+docstring = Vector(2)
+
+#Build docs
+for (call, msg, arg) in [doc_version, doc!_version] #Start
+i+=1
+docstring[i] = """
+$call
+
+$msg
+
+If `log` is set to `true` is given, method will output a tuple `x, ch`. Where
+`ch` is a `ConvergenceHistory` object. Otherwise it will only return `x`.
+The `plot` attribute can only be used when `log` is set version.
+
+**Arguments**
+
+$arg
+* `A`: linear operator.
+* `b`: right hand side.
+
+*Keywords*
+
+* `Pl = 1`: left preconditioner of the method.
+* `tol::Real = size(A,2)*eps()`: stopping tolerance.
+* `maxiter::Integer = size(A,2)`: maximum number of iterations.
+* `verbose::Bool = false`: print method information.
+* `log::Bool = false`: output an extra element of type `ConvergenceHistory`
+containing extra information of the method execution.
+* `plot::Bool = false`: plot data. (Only when `log` is set)
+
+**Output**
+
+*`log` is `false`:*
+
+* `x`: approximated solution.
+
+*`log` is `true`:*
+
+* `x`: approximated solution.
+* `ch`: convergence history.
+
+*ConvergenceHistory keys*
+
+* `:tol` => `::Real`: stopping tolerance.
+* `:resnom` => `::Vector`: residual norm at each iteration.
+
+"""
+end
+
+@doc docstring[1] -> cg
+@doc docstring[2] -> cg!
 end

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -1,30 +1,43 @@
 export chebyshev, chebyshev!
 
-chebyshev(A, b, λmin::Real, λmax::Real, Pr = 1, n = size(A,2);
-          tol::Real = sqrt(eps(typeof(real(b[1])))), maxiter::Int = n^3) =
-    chebyshev!(zerox(A, b), A, b, λmin, λmax, Pr, n; tol=tol,maxiter=maxiter)
+####################
+# API method calls #
+####################
 
-function chebyshev!(x, A, b, λmin::Real, λmax::Real, Pr = 1, n = size(A,2);
-	tol::Real = sqrt(eps(typeof(real(b[1])))), maxiter::Int = n^3
+chebyshev(A, b, λmin::Real, λmax::Real; kwargs...) =
+    chebyshev!(zerox(A, b), A, b, λmin, λmax; kwargs...)
+
+function chebyshev!(x, A, b, λmin::Real, λmax::Real;
+    n::Int=size(A,2), tol::Real = sqrt(eps(typeof(real(b[1])))),
+    maxiter::Int = n^3, plot::Bool=false, log::Bool=false, kwargs...
     )
-    history = ConvergenceHistory()
-    history[:tol] = tol
-    reserve!(history,:resnorm,maxiter)
-
 	K = KrylovSubspace(A, n, 1, Adivtype(A, b))
 	init!(K, x)
-	chebyshev_method!(history, x, K, b, λmin, λmax, Pr; tol = tol, maxiter = maxiter)
-    x, history
+
+    (plot & !log) && error("Can't plot when log keyword is false")
+    history = ConvergenceHistory(partial=!log)
+    history[:tol] = tol
+    reserve!(history,:resnorm,maxiter)
+    chebyshev_method!(history, x, K, b, λmin, λmax; tol=tol, maxiter=maxiter, kwargs...)
+    plot && (shrink!(history); showplot(history))
+    log ? (x, history) : x
 end
 
+#########################
+# Method Implementation #
+#########################
+
 function chebyshev_method!(
-    log::ConvergenceHistory, x, K::KrylovSubspace, b, λmin::Real, λmax::Real,
-    Pr = 1; tol::Real = sqrt(eps(typeof(real(b[1])))), maxiter::Int = K.n^3
+    log::ConvergenceHistory, x, K::KrylovSubspace, b, λmin::Real, λmax::Real;
+    Pr = 1, tol::Real = sqrt(eps(typeof(real(b[1])))), maxiter::Int = K.n^3,
+    verbose::Bool=false
     )
 
+    verbose && @printf("=== chebyshev ===\n%4s\t%7s\n","iter","resnorm")
 	local α, p
 	K.order = 1
     tol = tol*norm(b)
+    log.mvps=1
 	r = b - nextvec(K)
 	d::eltype(b) = (λmax + λmin)/2
 	c::eltype(b) = (λmax - λmin)/2
@@ -45,9 +58,85 @@ function chebyshev_method!(
 		#Check convergence
 		resnorm = norm(r)
         push!(log, :resnorm, resnorm)
+        verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         resnorm < tol && break
 	end
-    shrink!(log)
+    verbose && @printf("\n")
     setconv(log, 0<=norm(r)<tol)
 	x
+end
+
+#################
+# Documentation #
+#################
+
+let
+#Initialize parameters
+doc_call = """    chebyshev!(A, b, λmin, λmax)
+"""
+doc!_call = """    chebyshev!(x, A, b, λmin, λmax)
+"""
+
+doc_msg = "Solve A*x=b using the chebyshev method."
+doc!_msg = "Overwrite `x`.\n\n" * doc_msg
+
+doc_arg = ""
+doc!_arg = """* `x`: initial guess, overwrite final estimation."""
+
+doc_version = (doc_call, doc_msg, doc_arg)
+doc!_version = (doc!_call, doc!_msg, doc!_arg)
+
+i=0
+docstring = Vector(2)
+
+#Build docs
+for (call, msg, arg) in [doc_version, doc!_version] #Start
+i+=1
+docstring[i] = """
+$call
+
+$msg
+
+If `log` is set to `true` is given, method will output a tuple `x, ch`. Where
+`ch` is a `ConvergenceHistory` object. Otherwise it will only return `x`.
+
+The `plot` attribute can only be used when `log` is set version.
+
+**Arguments**
+
+$arg
+* `A`: linear operator.
+* `b`: right hand side.
+
+*Keywords*
+
+* `Pr = 1`: right preconditioner of the method.
+* `tol::Real = sqrt(eps())`: stopping tolerance.
+* `maxiter::Integer = size(A,2)^3`: maximum number of iterations.
+* `verbose::Bool = false`: print method information.
+* `log::Bool = false`: output an extra element of type `ConvergenceHistory`
+containing extra information of the method execution.
+* `plot::Bool = false`: plot data. (Only with `Master` version)
+
+**Output**
+
+*`log` is `false`:*
+
+* `x`: approximated solution.
+
+*`log` is `true`:*
+
+* `x`: approximated solution.
+* `ch`: convergence history.
+
+*ConvergenceHistory keys*
+
+* `:tol` => `::Real`: stopping tolerance.
+* `:resnom` => `::Vector`: residual norm at each iteration.
+
+"""
+end
+
+@doc docstring[1] -> chebyshev
+@doc docstring[2] -> chebyshev!
 end

--- a/src/lanczos.jl
+++ b/src/lanczos.jl
@@ -1,6 +1,27 @@
 import Base.LinAlg.BlasFloat
 
-export eigvals_lanczos
+export eiglancz
+
+####################
+# API method calls #
+####################
+
+function eiglancz(A;
+    maxiter::Integer=size(A,1), plot::Bool=false,
+    tol::Real = size(A,1)^3*eps(real(eltype(A))), log::Bool=false, kwargs...
+    )
+    (plot & !log) && error("Can't plot when log keyword is false")
+    history = ConvergenceHistory(partial=!log)
+    history[:tol] = tol
+    reserve!(history,:resnorm, maxiter)
+    e1 = eiglancz_method(history, A; maxiter=maxiter, tol=tol, kwargs...)
+    plot && (shrink!(history); showplot(history))
+    log ? (e1, history) : e1
+end
+
+#########################
+# Method Implementation #
+#########################
 
 function lanczos!{T}(K::KrylovSubspace{T})
     m = K.n
@@ -18,15 +39,11 @@ function lanczos!{T}(K::KrylovSubspace{T})
     SymTridiagonal(αs, βs)
 end
 
-function eigvals_lanczos(A, neigs::Int=size(A,1); tol::Real = size(A,1)^3*eps(real(eltype(A))), maxiter::Integer = size(A,1))
-    history = ConvergenceHistory()
-    history[:tol] = tol
-    reserve!(history,:resnorm, maxiter)
-    e1 = eiglancz_method!(history, A, neigs; maxiter=maxiter, tol=tol)
-    e1, history
-end
-
-function eiglancz_method!(log::ConvergenceHistory, A, neigs::Int=size(A,1); tol::Real = size(A,1)^3*eps(real(eltype(A))), maxiter::Integer = size(A,1))
+function eiglancz_method(log::ConvergenceHistory, A;
+    neigs::Int=size(A,1), tol::Real = size(A,1)^3*eps(real(eltype(A))),
+    maxiter::Integer=size(A,1), verbose::Bool=false
+    )
+    verbose && @printf("=== eiglancz ===\n%4s\t%7s\n","iter","resnorm")
     K = KrylovSubspace(A, size(A, 1), 2) #In Lanczos, only remember the last two vectors
     initrand!(K)
     e1 = eigvals(lanczos!(K), 1:neigs)
@@ -35,8 +52,62 @@ function eiglancz_method!(log::ConvergenceHistory, A, neigs::Int=size(A,1); tol:
         e0, e1 = e1, eigvals(lanczos!(K), 1:neigs)
         resnorm = norm(e1-e0)
         push!(log, :resnorm, resnorm)
+        verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         resnorm < tol && (setconv(log, resnorm>=0); break)
     end
-    shrink!(log)
+    verbose && @printf("\n")
     e1
+end
+
+#################
+# Documentation #
+#################
+
+let
+#Initialize parameters
+doc_call = """    eiglancz(A)
+"""
+
+doc_msg = "Find the most useful eigenvalues using the lanczos method."
+
+doc_arg = ""
+
+doc_version = (eiglancz, doc_call, doc_msg, doc_arg)
+
+i=0
+docstring = Vector(1)
+
+#Build docs
+for (func, call, msg, arg) in [doc_version]
+i+=1
+docstring[i] = """
+$call
+$msg
+If `log` is set to `true` is given, method will output a tuple `eigs, ch`. Where
+`ch` is a `ConvergenceHistory` object. Otherwise it will only return `eigs`.
+The `plot` attribute can only be used when `log` is set version.
+**Arguments**
+$arg
+* `A`: linear operator.
+*Keywords*
+* `neigs::Int = size(A,1)`: number of eigen values.
+* `tol::Real = size(A,1)^3*eps()`: stopping tolerance.
+* `maxiter::Integer=size(A,1)`: maximum number of iterations.
+* `verbose::Bool = false`: verbose flag.
+* `log::Bool = false`: output an extra element of type `ConvergenceHistory`
+containing extra information of the method execution.
+* `plot::Bool = false`: plot data. (Only when `log` is set)
+**Output**
+*`log` is `false`:*
+* `eigs::Vector`: eigen values.
+*`log` is `true`:*
+* `eigs::Vector`: eigen values.
+* `ch`: convergence history.
+*ConvergenceHistory keys*
+* `:tol` => `::Real`: stopping tolerance.
+* `:resnom` => `::Vector`: residual norm at each iteration.
+"""
+end
+
+@doc docstring[1] -> eiglancz
 end

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -2,46 +2,40 @@ export lsmr, lsmr!
 
 using Base.LinAlg
 
-##############################################################################
-## LSMR
-##
-## Minimize ||Ax-b||^2 + λ^2 ||x||^2
-##
-## Adapted from the BSD-licensed Matlab implementation at
-## http://web.stanford.edu/group/SOL/software/lsmr/
-##
-## A is a StridedVecOrMat or anything that implements
-## A_mul_B!(α, A, b, β, c) updates c -> α Ab + βc
-## Ac_mul_B!(α, A, b, β, c) updates c -> α A'b + βc
-## eltype(A)
-## size(A)
-## (this includes SparseMatrixCSC)
-## x, v, h, hbar are AbstractVectors or anything that implements
-## norm(x)
-## copy!(x1, x2)
-## scale!(x, α)
-## axpy!(α, x1, x2)
-## similar(x, T)
-## length(x)
-## b is an AbstractVector or anything that implements
-## eltype(b)
-## norm(b)
-## copy!(x1, x2)
-## fill!(b, α)
-## scale!(b, α)
-## similar(b, T)
-## length(b)
+####################
+# API method calls #
+####################
 
-##############################################################################
+lsmr(A, b; kwargs...) = lsmr!(zerox(A, b), A, b; kwargs...)
 
+function lsmr!(x, A, b;
+    plot::Bool=false, maxiter::Integer = max(size(A,1), size(A,2)),
+    log::Bool=false, kwargs...
+    )
+    (plot & !log) && error("Can't plot when log keyword is false")
+    history = ConvergenceHistory(partial=!log)
+    reserve!(history,[:anorm,:rnorm,:cnorm],maxiter)
 
-## Arguments:
-## x is initial x0. Transformed in place to the solution.
-## b equals initial b. Transformed in place
-## v, h, hbar are storage arrays of length size(A, 2)
+    T = Adivtype(A, b)
+    m, n = size(A, 1), size(A, 2)
+    btmp = similar(b, T)
+    copy!(btmp, b)
+    v, h, hbar = similar(x, T), similar(x, T), similar(x, T)
+    lsmr_method!(history, x, A, btmp, v, h, hbar; maxiter=maxiter, kwargs...)
+    plot && (shrink!(history); showplot(history))
+    log ? (x, history) : x
+end
+
+#########################
+# Method Implementation #
+#########################
+
 function lsmr_method!(log::ConvergenceHistory, x, A, b, v, h, hbar;
     atol::Number = 1e-6, btol::Number = 1e-6, conlim::Number = 1e8,
-    maxiter::Integer = max(size(A,1), size(A,2)), λ::Number = 0)
+    maxiter::Integer = max(size(A,1), size(A,2)), λ::Number = 0,
+    verbose::Bool=false
+    )
+    verbose && @printf("=== lsmr ===\n%4s\t%7s\t\t%7s\t\t%7s\n","iter","anorm","cnorm","rnorm")
 
     # Sanity-checking
     m = size(A, 1)
@@ -208,6 +202,7 @@ function lsmr_method!(log::ConvergenceHistory, x, A, b, v, h, hbar;
             push!(log, :cnorm, test3)
             push!(log, :anorm, test2)
             push!(log, :rnorm, test1)
+            verbose && @printf("%3d\t%1.2e\t%1.2e\t%1.2e\n",iter,test2,test3,test1)
 
             t1 = test1 / (one(Tr) + normA * normx / normb)
             rtol = btol + atol * normA * normx / normb
@@ -226,28 +221,9 @@ function lsmr_method!(log::ConvergenceHistory, x, A, b, v, h, hbar;
             if test1 <= rtol  istop = 1; break end
         end
     end
-    shrink!(log)
+    verbose && @printf("\n")
     setconv(log, istop ∉ (3, 6, 7))
     x
-end
-
-## Arguments:
-## x is initial x0. Transformed in place to the solution.
-function lsmr!(x, A, b; maxiter::Integer = max(size(A,1)), kwargs...)
-    history = ConvergenceHistory()
-    reserve!(history,[:anorm,:rnorm,:cnorm],maxiter)
-
-    T = Adivtype(A, b)
-    m, n = size(A, 1), size(A, 2)
-    btmp = similar(b, T)
-    copy!(btmp, b)
-    v, h, hbar = similar(x, T), similar(x, T), similar(x, T)
-    lsmr_method!(history, x, A, btmp, v, h, hbar; maxiter=maxiter, kwargs...)
-    x, history
-end
-
-function lsmr(A, b; kwargs...)
-    lsmr!(zerox(A, b), A, b; kwargs...)
 end
 
 for (name, symbol) in ((:Ac_mul_B!, 'T'), (:A_mul_B!, 'N'))
@@ -256,4 +232,98 @@ for (name, symbol) in ((:Ac_mul_B!, 'T'), (:A_mul_B!, 'N'))
             BLAS.gemm!($symbol, 'N', convert(eltype(y), α), A, x, convert(eltype(y), β), y)
         end
     end
+end
+
+#################
+# Documentation #
+#################
+
+let
+#Initialize parameters
+doc_call = """    lsmr(A, b)
+"""
+doc!_call = """    lsmr!(x, A, b)
+"""
+
+doc_msg = "Minimize ||Ax-b||^2 + λ^2 ||x||^2 for A*x=b.\n"
+doc!_msg = "Overwrite `x`.\n\n" * doc_msg
+
+doc_arg = ""
+doc!_arg = """* `x`: initial guess, overwrite final estimation."""
+
+doc_version = (lsmr, doc_call, doc_msg, doc_arg)
+doc!_version = (lsmr!, doc!_call, doc!_msg, doc!_arg)
+
+i=0
+docstring = Vector(2)
+
+#Build docs
+for (func, call, msg, arg) in [doc_version, doc!_version]
+i+=1
+docstring[i] =  """
+$call
+
+$msg
+
+The method is based on the Golub-Kahan bidiagonalization process. It is
+algebraically equivalent to applying MINRES to the normal equation (ATA+λ2I)x=ATb,
+but has better numerical properties, especially if A is ill-conditioned.
+
+If `log` is set to `true` is given, method will output a tuple `x, ch`. Where
+`ch` is a `ConvergenceHistory` object. Otherwise it will only return `x`.
+
+The `plot` attribute can only be used when `log` is set version.
+
+**Arguments**
+
+$arg
+* `A`: linear operator.
+* `b`: right hand side.
+
+*Keywords*
+
+* `λ::Number = 0`: lambda.
+* `atol::Number = 1e-6`, `btol::Number = 1e-6`: stopping tolerances. If both are
+1.0e-9 (say), the final residual norm should be accurate to about 9 digits.
+(The final `x` will usually have fewer correct digits,
+depending on `cond(A)` and the size of damp).
+* `conlim::Number = 1e8`: stopping tolerance.  `lsmr` terminates if an estimate
+of `cond(A)` exceeds conlim.  For compatible systems Ax = b,
+conlim could be as large as 1.0e+12 (say).  For least-squares
+problems, conlim should be less than 1.0e+8.
+Maximum precision can be obtained by setting
+`atol` = `btol` = `conlim` = zero, but the number of iterations
+may then be excessive.
+* `maxiter::Integer = min(20,length(b))`: maximum number of iterations.
+* `verbose::Bool = false`: print method information.
+* `log::Bool = false`: output an extra element of type `ConvergenceHistory`
+containing extra information of the method execution.
+* `plot::Bool = false`: plot data. (Only when `log` is set)
+
+**Output**
+
+*`log` is `false`:*
+
+* `x`: approximated solution.
+
+*`log` is `true`:*
+
+* `x`: approximated solution.
+* `ch`: convergence history.
+
+*ConvergenceHistory keys*
+
+* `:atol` => `::Real`: atol stopping tolerance.
+* `:btol` => `::Real`: btol stopping tolerance.
+* `:ctol` => `::Real`: ctol stopping tolerance.
+* `:anorm` => `::Real`: anorm.
+* `:rnorm` => `::Real`: rnorm.
+* `:cnorm` => `::Real`: cnorm.
+* `:resnom` => `::Vector`: residual norm at each iteration.
+
+"""
+end
+
+@doc docstring[1] -> lsmr
+@doc docstring[2] -> lsmr!
 end

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -1,11 +1,34 @@
 #Simple methods
+export powm, invpowm, rqi
 
-export eigvals_power, eigvals_ii, eigvals_rqi
+####################
+# API method calls #
+####################
 
+function powm(A;
+    x=nothing, tol::Real=eps(eltype(A))*size(A,2)^3, maxiter::Int=size(A,2),
+    plot::Bool=false, log::Bool=false, kwargs...
+    )
+    K = KrylovSubspace(A, 1)
+    x==nothing ? initrand!(K) : init!(K, x/norm(x))
+
+    (plot & !log) && error("Can't plot when log keyword is false")
+    history = ConvergenceHistory(partial=!log)
+    history[:tol] = tol
+    reserve!(history,:resnorm, maxiter)
+    eig, v = powm_method!(history, K; tol=tol, maxiter=maxiter, kwargs...)
+    plot && (shrink!(history); showplot(history))
+    log ? (eig, v, history) : (eig, v)
+end
+
+#########################
+# Method Implementation #
+#########################
 
 function powm_method!{T}(log::ConvergenceHistory, K::KrylovSubspace{T};
-    tol::Real=eps(T)*K.n^3, maxiter::Int=K.n
+    tol::Real=eps(T)*K.n^3, maxiter::Int=K.n, verbose::Bool=false
     )
+    verbose && @printf("=== powm ===\n%4s\t%7s\n","iter","resnorm")
     θ = zero(T)
     v = Array(T, K.n)
     for iter=1:maxiter
@@ -15,31 +38,42 @@ function powm_method!{T}(log::ConvergenceHistory, K::KrylovSubspace{T};
         θ = dot(v, y)
         resnorm = real(norm(y - θ*v))
         push!(log, :resnorm, resnorm)
+        verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         resnorm <= tol*abs(θ) && (setconv(log, resnorm >= 0); break)
         appendunit!(K, y)
     end
-    Eigenpair(θ, v)
+    verbose && @printf("\n")
+    θ, v
 end
 
-function eigvals_power(A, x=nothing; tol::Real=size(A,1)^3*eps(), maxiter::Int=size(A,1))
+####################
+# API method calls #
+####################
+
+function invpowm(A;
+    x=nothing, shift::Number=0, tol::Real=eps(eltype(A))*size(A,2)^3,
+    maxiter::Int=size(A,2), plot::Bool=false, log::Bool=false, kwargs...
+    )
     K = KrylovSubspace(A, 1)
     x==nothing ? initrand!(K) : init!(K, x/norm(x))
-    eigvals_power(K; tol=tol, maxiter=maxiter)
-end
-function eigvals_power(K::KrylovSubspace, x=nothing;
-    tol::Real=size(A,1)^3*eps(), maxiter::Int=size(A,1)
-    )
-    history = ConvergenceHistory()
+
+    (plot & !log) && error("Can't plot when log keyword is false")
+    history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
-    pair = powm_method!(history, K; tol=tol, maxiter=maxiter)
-    pair, history
+    eig, v = invpowm_method!(history, K, shift; tol=tol, maxiter=maxiter, kwargs...)
+    plot && (shrink!(history); showplot(history))
+    log ? (eig, v, history) : (eig, v)
 end
 
-#Inverse iteration/inverse power method
+#########################
+# Method Implementation #
+#########################
+
 function invpowm_method!{T}(log::ConvergenceHistory, K::KrylovSubspace{T}, σ::Number=zero(T);
-    tol::Real=eps(T)*K.n^3, maxiter::Int=K.n
+    tol::Real=eps(T)*K.n^3, maxiter::Int=K.n, verbose::Bool=false
     )
+    verbose && @printf("=== invpowm ===\n%4s\t%7s\n","iter","resnorm")
     θ = zero(T)
     v = Array(T, K.n)
     y = Array(T, K.n)
@@ -51,31 +85,44 @@ function invpowm_method!{T}(log::ConvergenceHistory, K::KrylovSubspace{T}, σ::N
         θ = dot(v, y)
         resnorm = norm(y - θ*v)
         push!(log, :resnorm, resnorm)
+        verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         resnorm <= tol*abs(θ) && (setconv(log, resnorm >= 0); break)
         appendunit!(K, y)
     end
-    shrink!(log)
-    Eigenpair(σ+1/θ, y/θ)
+    verbose && @printf("\n")
+    σ+1/θ, y/θ
 end
 
-function eigvals_ii(A, σ::Number, x=nothing; tol::Real=eps(), maxiter::Int=size(A,1))
+####################
+# API method calls #
+####################
+
+function rqi(A;
+    x=nothing, shift::Number=0, tol::Real=eps(eltype(A))*size(A,2)^3,
+    maxiter::Int=size(A,2), plot::Bool=false, log::Bool=false, kwargs...
+    )
     K = KrylovSubspace(A, 1)
     x==nothing ? initrand!(K) : init!(K, x/norm(x))
-    eigvals_ii(K, σ; tol=tol, maxiter=maxiter)
-end
-function eigvals_ii(K::KrylovSubspace, σ::Number, x=nothing;
-    tol::Real=size(A,1)^3*eps(), maxiter::Int=size(A,1)
-    )
-    history = ConvergenceHistory()
+
+    (plot & !log) && error("Can't plot when log keyword is false")
+    history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
-    pair = invpowm_method!(history, K, σ; tol=tol, maxiter=maxiter)
-    pair, history
+    eig, v = rqi_method!(history, K, shift; tol=tol, maxiter=maxiter, kwargs...)
+    plot && (shrink!(history); showplot(history))
+    log ? (eig, v, history) : (eig, v)
 end
+
+#########################
+# Method Implementation #
+#########################
 
 #Rayleigh quotient iteration
 #XXX Doesn't work well
-function rqi_method!{T}(log::ConvergenceHistory, K::KrylovSubspace{T}, σ::Number; tol::Real=eps(T), maxiter::Int=K.n)
+function rqi_method!{T}(log::ConvergenceHistory, K::KrylovSubspace{T}, σ::Number;
+    tol::Real=eps(T), maxiter::Int=K.n, verbose::Bool=false
+    )
+    verbose && @printf("=== rqi ===\n%4s\t%7s\n","iter","resnorm")
     v = lastvec(K)
     ρ = dot(v, nextvec(K))
     for iter=1:maxiter
@@ -86,21 +133,96 @@ function rqi_method!{T}(log::ConvergenceHistory, K::KrylovSubspace{T}, σ::Numbe
         v = y/θ
         resnorm=1/θ
         push!(log,:resnorm,resnorm)
+        verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         θ >= 1/tol && (setconv(log, resnorm >= 0); break)
     end
-    shrink!(history)
-    Eigenpair(ρ, v)
+    verbose && @printf("\n")
+    ρ, v
 end
 
-function eigvals_rqi(A, σ::Number, x=nothing; tol::Real=eps(), maxiter::Int=size(A,1))
-    K = KrylovSubspace(A, 1)
-    x==nothing ? initrand!(K) : init!(K, x/norm(x))
-    eigvals_rqi(K, σ; tol=tol, maxiter=maxiter)
+#################
+# Documentation #
+#################
+
+let
+#Initialize parameters
+doc1_call = """    powm(A)
+"""
+doc2_call = """    invpowm(A)
+"""
+doc3_call = """    rqi(A)
+"""
+doc1_msg = """Find biggest eigenvalue of `A` and its associated eigenvector
+using the power method.
+"""
+doc2_msg = """Find closest eigenvalue of `A` to `shift` and its associated eigenvector
+using the inverse power iteration method.
+"""
+doc3_msg = """Try find closest eigenvalue of `A` to `shift` and its associated eigenvector
+using the rayleigh quotient iteration method. This method converges rapidly
+but is not guaranteed to compute the eigenvalue closes to `shift`.
+"""
+doc1_karg = ""
+doc2_karg = "* `shift::Number=0`: shift to be applied to matrix A."
+doc3_karg = "* `shift::Number=0`: shift to be applied to matrix A."
+
+doc1_version = (powm, doc1_call, doc1_msg, doc1_karg)
+doc2_version = (invpowm, doc2_call, doc2_msg, doc2_karg)
+doc3_version = (rqi, doc3_call, doc3_msg, doc3_karg)
+
+i=0
+docstring = Vector(3)
+
+#Build docs
+for (func, call, msg, karg) in [doc1_version, doc2_version, doc3_version]
+i+=1
+docstring[i] = """
+$call
+
+$msg
+
+If `log` is set to `true` is given, method will output a tuple `eig, v, ch`. Where
+`ch` is a `ConvergenceHistory` object. Otherwise it will only return `eig, v`.
+The `plot` attribute can only be used when `log` is set version.
+
+**Arguments**
+
+* `K::KrylovSubspace`: krylov subspace.
+* `A`: linear operator.
+
+*Keywords*
+
+$karg
+* `x = random unit vector`: initial eigenvector guess.
+* `tol::Real = eps()*size(A,2)^3`: stopping tolerance.
+* `maxiter::Integer = size(A,2)`: maximum number of iterations.
+* `verbose::Bool = false`: verbose flag.
+* `log::Bool = false`: output an extra element of type `ConvergenceHistory`
+containing extra information of the method execution.
+* `plot::Bool = false`: plot data. (Only when `log` is set)
+
+**Output**
+
+*`log` is `false`:*
+
+* `eig::Real`: eigen value
+* `v::Vector`: eigen vector
+
+*`log` is `true`:*
+
+* `eig::Real`: eigen value
+* `v::Vector`: eigen vector
+* `ch`: convergence history.
+
+*ConvergenceHistory keys*
+
+* `:tol` => `::Real`: stopping tolerance.
+* `:resnom` => `::Vector`: residual norm at each iteration.
+
+"""
 end
-function eigvals_rqi{T}(K::KrylovSubspace{T}, σ::Number, x=nothing; tol::Real=eps(T), maxiter::Int=K.n)
-    history = ConvergenceHistory()
-    history[:tol] = tol
-    reserve!(history,:resnorm, maxiter)
-    rqi_method(history, K, σ, tol=tol, maxiter=maxiter)
-    x, history
+
+@doc docstring[1] -> powm
+@doc docstring[2] -> invpowm
+@doc docstring[3] -> rqi
 end

--- a/src/stationary.jl
+++ b/src/stationary.jl
@@ -2,21 +2,34 @@
 #Templates, section 2.2
 export jacobi, jacobi!, gauss_seidel, gauss_seidel!, sor, sor!, ssor, ssor!
 
-jacobi(A::AbstractMatrix, b;
-       tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2) =
-    jacobi!(zerox(A, b), A, b; tol=tol, maxiter=maxiter)
+####################
+# API method calls #
+####################
+
+jacobi(A::AbstractMatrix, b; kwargs...) = jacobi!(zerox(A, b), A, b; kwargs...)
 
 function jacobi!(x, A::AbstractMatrix, b;
-        tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2)
-    history = ConvergenceHistory()
+    tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2,
+    plot::Bool=false, log::Bool=false, kwargs...
+    )
+    (plot & !log) && error("Can't plot when log keyword is false")
+    history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
-    jacobi_method!(history, x, A, b; tol=tol, maxiter=maxiter)
-    x, history
+    jacobi_method!(history, x, A, b; tol=tol, maxiter=maxiter, kwargs...)
+    plot && (shrink!(history); showplot(history))
+    log ? (x, history) : x
 end
 
+#########################
+# Method Implementation #
+#########################
+
 function jacobi_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b;
-        tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2)
+    tol=size(A,2)^3*eps(typeof(real(b[1]))),maxiter=size(A,2)^2,
+    verbose::Bool=false
+    )
+    verbose && @printf("=== jacobi ===\n%4s\t%7s\n","iter","resnorm")
     iter=0
     n = size(A,2)
     xold = copy(x)
@@ -35,28 +48,43 @@ function jacobi_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b;
 		#check convergence
         resnorm = norm(A*x-b)
         push!(log,:resnorm,resnorm)
+        verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
 		resnorm < tol && (setconv(log, resnorm>=0); break)
 		copy!(xold, x)
 	end
-    shrink!(log)
+    verbose && @printf("\n")
 	x
 end
 
-gauss_seidel(A::AbstractMatrix, b;
-        tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2) =
-    gauss_seidel!(zerox(A, b), A, b; tol=tol, maxiter=maxiter)
+####################
+# API method calls #
+####################
+
+gauss_seidel(A::AbstractMatrix, b; kwargs...) =
+    gauss_seidel!(zerox(A, b), A, b; kwargs...)
 
 function gauss_seidel!(x, A::AbstractMatrix, b;
-        tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2)
-    history = ConvergenceHistory()
+    tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2,
+    plot::Bool=false, log::Bool=false, kwargs...
+    )
+    (plot & !log) && error("Can't plot when log keyword is false")
+    history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
-    gauss_seidel_method!(history, x, A, b; tol=tol, maxiter=maxiter)
-    x, history
+    gauss_seidel_method!(history, x, A, b; tol=tol, maxiter=maxiter, kwargs...)
+    plot && (shrink!(history); showplot(history))
+    log ? (x, history) : x
 end
 
+#########################
+# Method Implementation #
+#########################
+
 function gauss_seidel_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b;
-        tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2)
+    tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2,
+    verbose::Bool=false
+    )
+    verbose && @printf("=== gauss_seidel ===\n%4s\t%7s\n","iter","resnorm")
     iter=0
     n = size(A,2)
     xold = copy(x)
@@ -78,31 +106,45 @@ function gauss_seidel_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b;
 		#check convergence
 		resnorm = norm(A*x-b)
         push!(log,:resnorm,resnorm)
+        verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         resnorm < tol && (setconv(log, resnorm>=0); break)
 		copy!(xold, x)
 	end
-    shrink!(log)
+    verbose && @printf("\n")
 	x
 end
 
-#Successive overrelaxation
-sor(A::AbstractMatrix, b, ω::Real;
-    tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2) =
-    sor!(zerox(A, b), A, b, ω; tol=tol, maxiter=maxiter)
+####################
+# API method calls #
+####################
+
+sor(A::AbstractMatrix, b, ω::Real; kwargs...) =
+    sor!(zerox(A, b), A, b, ω; kwargs...)
 
 function sor!(x, A::AbstractMatrix, b, ω::Real;
-        tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2)
-    history = ConvergenceHistory()
+    tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2,
+    plot::Bool=false, log::Bool=false, kwargs...
+    )
+    (plot & !log) && error("Can't plot when log keyword is false")
+    history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
-    sor_method!(history, x, A, b, ω; tol=tol, maxiter=maxiter)
-    x, history
+    sor_method!(history, x, A, b, ω; tol=tol, maxiter=maxiter, kwargs...)
+    plot && (shrink!(history); showplot(history))
+    log ? (x, history) : x
 end
 
+#########################
+# Method Implementation #
+#########################
+
 function sor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real;
-        tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2)
+    tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2,
+    verbose::Bool=false
+    )
 	0 < ω < 2 || warn("ω = $ω lies outside the range 0<ω<2 which is required for convergence")
 
+    verbose && @printf("=== sor ===\n%4s\t%7s\n","iter","resnorm")
     iter=0
 	n = size(A,2)
     xold = copy(x)
@@ -125,32 +167,45 @@ function sor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real;
 		#check convergence
 		resnorm = norm(A*x-b)
         push!(log,:resnorm,resnorm)
+        verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         resnorm < tol && (setconv(log, resnorm>=0); break)
 		copy!(xold, x)
 	end
-    shrink!(log)
+    verbose && @printf("\n")
 	x
 end
 
-#Symmetric successive overrelaxation
-#A must be symmetric
-ssor(A::AbstractMatrix, b, ω::Real;
-     tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)) =
-    ssor!(zerox(A, b), A, b, ω; tol=tol, maxiter=maxiter)
+####################
+# API method calls #
+####################
+
+ssor(A::AbstractMatrix, b, ω::Real; kwargs...) =
+    ssor!(zerox(A, b), A, b, ω; kwargs...)
 
 function ssor!(x, A::AbstractMatrix, b, ω::Real;
-        tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2))
-    history = ConvergenceHistory()
+    tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2),
+    plot::Bool=false, log::Bool=false, kwargs...
+    )
+    (plot & !log) && error("Can't plot when log keyword is false")
+    history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
-    ssor_method!(history, x, A, b, ω; tol=tol, maxiter=maxiter)
-    x, history
+    ssor_method!(history, x, A, b, ω; tol=tol, maxiter=maxiter, kwargs...)
+    plot && (shrink!(history); showplot(history))
+    log ? (x, history) : x
 end
 
+#########################
+# Method Implementation #
+#########################
+
 function ssor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real;
-        tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2))
+    tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2),
+    verbose::Bool=false
+    )
 	0 < ω < 2 || warn("ω = $ω lies outside the range 0<ω<2 which is required for convergence")
 
+    verbose && @printf("=== sor ===\n%4s\t%7s\n","iter","resnorm")
     iter=0
 	n = size(A,2)
     xold = copy(x)
@@ -186,9 +241,115 @@ function ssor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real
 		#check convergence
 		resnorm = norm(A*x-b)
         push!(log,:resnorm,resnorm)
+        verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         resnorm < tol && (setconv(log, resnorm>=0); break)
 		copy!(xold, x)
 	end
-    shrink!(log)
+    verbose && @printf("\n")
 	x
+end
+
+#################
+# Documentation #
+#################
+
+let
+#Initialize parameters
+doc1_call = """    jacobi(A, b)
+"""
+doc1!_call = """    jacobi!(x, A, b)
+"""
+doc2_call = """    gauss_seidel(A, b)
+"""
+doc2!_call = """    gauss_seidel!(x, A, b)
+"""
+doc3_call = """    sor(A, b, ω)
+"""
+doc3!_call = """    sor!(x, A, b, ω)
+"""
+doc4_call = """    ssor(A, b, ω)
+"""
+doc4!_call = """    ssor!(x, A, b, ω)
+"""
+doc1_msg = "Solve A*x=b with the Jacobi method."
+doc2_msg = "Solve A*x=b with the Gauss-Seidel method."
+doc3_msg = "Solve A*x=b with the successive overrelaxation method."
+doc4_msg = "Solve A*x=b with the symmetric successive overrelaxation method."
+doc1!_msg = "Overwrite `x`.\n\n" * doc1_msg
+doc2!_msg = "Overwrite `x`.\n\n" * doc2_msg
+doc3!_msg = "Overwrite `x`.\n\n" * doc3_msg
+doc4!_msg = "Overwrite `x`.\n\n" * doc4_msg
+doc1_arg = ""
+doc2_arg = ""
+doc3_arg = "* `shift::Number=0`: shift to be applied to matrix A."
+doc4_arg = "* `shift::Number=0`: shift to be applied to matrix A."
+doc1!_arg = "* `x`: initial guess, overwrite final estimation."
+doc2!_arg = "* `x`: initial guess, overwrite final estimation."
+doc3!_arg = "* `x`: initial guess, overwrite final estimation.\n\n$doc3_arg"
+doc4!_arg = "* `x`: initial guess, overwrite final estimation.\n\n$doc4_arg"
+
+doc1_version = (jacobi, doc1_call, doc1_msg, doc1_arg)
+doc2_version = (gauss_seidel, doc2_call, doc2_msg, doc2_arg)
+doc3_version = (sor, doc3_call, doc3_msg, doc3_arg)
+doc4_version = (ssor, doc4_call, doc4_msg, doc4_arg)
+doc1!_version = (jacobi!, doc1!_call, doc1!_msg, doc1!_arg)
+doc2!_version = (gauss_seidel!, doc2!_call, doc2!_msg, doc2!_arg)
+doc3!_version = (sor!, doc3!_call, doc3!_msg, doc3!_arg)
+doc4!_version = (ssor!, doc4!_call, doc4!_msg, doc4!_arg)
+
+i=0
+docstring = Vector(8)
+
+#Build docs
+for (func, call, msg, arg) in [doc1_version, doc2_version, doc3_version, doc4_version,
+                                doc1!_version, doc2!_version, doc3!_version, doc4!_version]
+i+=1
+docstring[i] = """
+$call
+
+$msg
+
+`ch` is a `ConvergenceHistory` object. Otherwise it will only return `x`.
+If `log` is set to `true` is given, method will output a tuple `x, ch`. Where
+The `plot` attribute can only be used when `log` is set version.
+
+**Arguments**
+
+$arg
+* `A`: linear operator.
+*Keywords*
+* `tol::Real = size(A,2)^3*eps()`: stopping tolerance.
+* `maxiter::Integer = size(A,2)^2`: maximum number of iterations.
+* `verbose::Bool = false`: verbose flag.
+* `log::Bool = false`: output an extra element of type `ConvergenceHistory`
+containing extra information of the method execution.
+* `plot::Bool = false`: plot data. (Only when `log` is set)
+
+**Output**
+
+*`log` is `false`:*
+
+* `x`: approximated solution.
+
+*`log` is `true`:*
+
+* `x`: approximated solution.
+* `ch`: convergence history.
+
+*ConvergenceHistory keys*
+
+* `:tol` => `::Real`: stopping tolerance.
+* `:resnom` => `::Vector`: residual norm at each iteration.
+
+"""
+end
+
+@doc docstring[1] -> jacobi
+@doc docstring[5] -> jacobi!
+@doc docstring[2] -> gauss_seidel
+@doc docstring[6] -> gauss_seidel!
+@doc docstring[3] -> sor
+@doc docstring[7] -> sor!
+@doc docstring[4] -> ssor
+@doc docstring[8] -> ssor!
 end

--- a/test/cg.jl
+++ b/test/cg.jl
@@ -11,19 +11,22 @@ context("Small full system") do
     A = A'*A
     rhs = randn(N)
     tol = 1e-12
-    x,ch = cg(A,rhs;tol=tol, maxiter=2*N)
 
+    x = cg(A,rhs;tol=tol, maxiter=2*N)
+    @fact norm(A*x - rhs) --> less_than(cond(A)*√tol)
+
+    x,ch = cg(A,rhs;tol=tol, maxiter=2*N, log=true)
     @fact norm(A*x - rhs) --> less_than(cond(A)*√tol)
     @fact ch.isconverged --> true
 
     # If you start from the exact solution, you should converge immediately
-    x2,ch2 = cg!(A\rhs, A, rhs; tol=tol*10)
-    @fact length(ch2[:resnorm]) --> less_than_or_equal(1)
+    x2, ch2 = cg!(A\rhs, A, rhs; tol=tol*10, log=true)
+    @fact niters(ch2) --> less_than_or_equal(1)
 
     # Test with cholfact should converge immediately
     F = cholfact(A)
-    x2,ch2 = cg(A, rhs, F)
-    @fact length(ch2[:resnorm]) --> less_than_or_equal(2)
+    x2,ch2 = cg(A, rhs; Pl=F, log=true)
+    @fact niters(ch2) --> less_than_or_equal(2)
 end
 
 context("Sparse Laplacian") do
@@ -39,9 +42,9 @@ context("Sparse Laplacian") do
     tol = 1e-5
 
     context("matrix") do
-        xCG, = cg(A,rhs;tol=tol,maxiter=100)
-        xJAC, = cg(A,rhs,JAC;tol=tol,maxiter=100)
-        xSGS, = cg(A,rhs,SGS;tol=tol,maxiter=100)
+        xCG = cg(A,rhs;tol=tol,maxiter=100)
+        xJAC = cg(A,rhs;Pl=JAC,tol=tol,maxiter=100)
+        xSGS = cg(A,rhs;Pl=SGS,tol=tol,maxiter=100)
         @fact norm(A*xCG - rhs) --> less_than_or_equal(tol)
         @fact norm(A*xSGS - rhs) --> less_than_or_equal(tol)
         @fact norm(A*xJAC - rhs) --> less_than_or_equal(tol)
@@ -49,9 +52,9 @@ context("Sparse Laplacian") do
 
     Af = MatrixFcn(A)
     context("function") do
-        xCG, = cg(Af,rhs;tol=tol,maxiter=100)
-        xJAC, = cg(Af,rhs,JAC;tol=tol,maxiter=100)
-        xSGS, = cg(Af,rhs,SGS;tol=tol,maxiter=100)
+        xCG = cg(Af,rhs;tol=tol,maxiter=100)
+        xJAC = cg(Af,rhs;Pl=JAC,tol=tol,maxiter=100)
+        xSGS = cg(Af,rhs;Pl=SGS,tol=tol,maxiter=100)
         @fact norm(A*xCG - rhs) --> less_than_or_equal(tol)
         @fact norm(A*xSGS - rhs) --> less_than_or_equal(tol)
         @fact norm(A*xJAC - rhs) --> less_than_or_equal(tol)
@@ -60,16 +63,16 @@ context("Sparse Laplacian") do
     context("function with specified starting guess") do
         tol = 1e-4
         x0 = randn(size(rhs))
-        xCG, hCG = cg!(copy(x0),Af,rhs,identity;tol=tol,maxiter=100)
-        xJAC, hJAC = cg!(copy(x0),Af,rhs,JAC;tol=tol,maxiter=100)
-        xSGS, hSGS = cg!(copy(x0),Af,rhs,SGS;tol=tol,maxiter=100)
+        xCG, hCG = cg!(copy(x0),Af,rhs;Pl=identity,tol=tol,maxiter=100, log=true)
+        xJAC, hJAC = cg!(copy(x0),Af,rhs;Pl=JAC,tol=tol,maxiter=100, log=true)
+        xSGS, hSGS = cg!(copy(x0),Af,rhs;Pl=SGS,tol=tol,maxiter=100, log=true)
         @fact norm(A*xCG - rhs) --> less_than_or_equal(tol)
         @fact norm(A*xSGS - rhs) --> less_than_or_equal(tol)
         @fact norm(A*xJAC - rhs) --> less_than_or_equal(tol)
 
-        iterCG = length(hCG[:resnorm])
-        iterJAC = length(hJAC[:resnorm])
-        iterSGS = length(hSGS[:resnorm])
+        iterCG = niters(hCG)
+        iterJAC = niters(hJAC)
+        iterSGS = niters(hSGS)
         @fact iterJAC --> iterCG
         @fact iterSGS --> less_than_or_equal(iterJAC) "Preconditioner increased the number of iterations"
     end

--- a/test/lsmr.jl
+++ b/test/lsmr.jl
@@ -133,7 +133,7 @@ facts(string("lsmr")) do
     context("Small dense matrix") do
         A = rand(10, 5)
         b = rand(10)
-        x, = lsmr(A, b)
+        x = lsmr(A, b)
         @fact norm(x - A\b) --> less_than(√eps())
     end
 
@@ -163,7 +163,7 @@ facts(string("lsmr")) do
             xtrue = n:-1:1
             b = Array(Float64, m)
             b = float(A_mul_B!(1.0, A, xtrue, 0.0, b))
-            x, = lsmr(A, b, atol = 1e-7, btol = 1e-7, conlim = 1e10, maxiter = 10n)
+            x = lsmr(A, b, atol = 1e-7, btol = 1e-7, conlim = 1e10, maxiter = 10n)
             r = A_mul_B!(-1, A, x, 1, b)
             @fact norm(r) --> less_than_or_equal(1e-4)
         end
@@ -183,7 +183,7 @@ facts(string("lsmr")) do
             v = rand(n)
             Adampened = DampenedMatrix(A, v)
             bdampened = DampenedVector(b, zeros(n))
-            x, ch = lsmr(Adampened, bdampened)
+            x, ch = lsmr(Adampened, bdampened, log=true)
             @fact norm((A'A + diagm(v).^2)x - A'b) --> less_than(1e-3)
         end
         DampenedTest(10, 10)

--- a/test/lsqr.jl
+++ b/test/lsqr.jl
@@ -7,7 +7,7 @@ facts("lsqr") do
 context("Small dense matrix") do
     A = rand(10, 5)
     b = rand(10)
-    x, = lsqr(A, b)
+    x = lsqr(A, b)
     @fact norm(x - A\b) --> less_than(√eps())
 end
 
@@ -23,7 +23,7 @@ context("SOL test") do
         A = MatrixCFcn{Int}(m, n, fmul, fcmul)
         xtrue = n:-1:1
         b = float(A*xtrue)
-        x, = lsqr(A, b, atol = 1e-6, btol = 1e-6, conlim = 1e10, maxiter = 10n)
+        x = lsqr(A, b, atol = 1e-6, btol = 1e-6, conlim = 1e10, maxiter = 10n)
         r = b - A*x
         @fact norm(r) --> less_than_or_equal(1e-4)
         x
@@ -79,7 +79,7 @@ context("Issue 64") do
     A=sprand(n,n,.5)
     b=rand(n)
 
-    x, ch = lsqr(A,b,maxiter=100)
+    x, ch = lsqr(A,b,maxiter=100, log=true)
     resnorm = norm(A*x - b)
     @fact resnorm --> less_than(√eps())
     @fact ch.isconverged --> true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,24 +26,24 @@ facts("Stationary solvers") do
         T<:Complex && (x0+=convert(Vector{T}, im*randn(n)))
         x = A\b
         for solver in [jacobi, gauss_seidel]
-            xi, ci=solver(A, b, maxiter=n^4)
+            xi, ci=solver(A, b, maxiter=n^4, log=true)
             @fact ci.isconverged --> true
             @fact norm(x-xi) --> less_than(n^3*eps(typeof(real(b[1]))))
         end
         for solver in [jacobi!, gauss_seidel!]
-            xi, ci=solver(copy(x0), A, b, maxiter=n^4)
+            xi, ci=solver(copy(x0), A, b, maxiter=n^4, log=true)
             @fact ci.isconverged --> true
             @fact norm(x-xi) --> less_than(n^3*eps(typeof(real(b[1]))))
         end
 
         ω = 0.5
         for solver in [sor, ssor]
-            xi, ci=solver(A, b, ω, maxiter=n^4)
+            xi, ci=solver(A, b, ω, maxiter=n^4, log=true)
             @fact ci.isconverged --> true
             @fact norm(x-xi) --> less_than(n^3*eps(typeof(real(b[1]))))
         end
         for solver in [sor!, ssor!]
-            xi, ci=solver(copy(x0), A, b, ω, maxiter=n^4)
+            xi, ci=solver(copy(x0), A, b, ω, maxiter=n^4, log=true)
             @fact ci.isconverged --> true
             @fact norm(x-xi) --> less_than(n^3*eps(typeof(real(b[1]))))
         end
@@ -74,15 +74,15 @@ for T in (Float32, Float64, Complex64, Complex128)
     F = lufact(A)
     b = b/norm(b)
 
-    x_gmres, c_gmres = gmres(A, b, L, R)
+    x_gmres, c_gmres = gmres(A, b, Pl=L, Pl=R, log=true)
     @fact c_gmres.isconverged --> true
     @fact norm(A*x_gmres - b) --> less_than(√eps(real(one(T))))
 
-    x_gmres, c_gmres = gmres(A, b, F; maxiter=1, restart=1)
+    x_gmres, c_gmres = gmres(A, b, Pl=F, maxiter=1, restart=1, log=true)
     @fact c_gmres.isconverged --> true
     @fact norm(A*x_gmres - b) --> less_than(√eps(real(one(T))))
 
-    x_gmres, c_gmres = gmres(A, b, 1, F; maxiter=1, restart=1)
+    x_gmres, c_gmres = gmres(A, b, Pl=1, Pr=F, maxiter=1, restart=1, log=true)
     @fact c_gmres.isconverged --> true
     @fact norm(A*x_gmres - b) --> less_than(√eps(real(one(T))))
     end
@@ -103,15 +103,15 @@ for T in (Float64, Complex128)
     F = lufact(A)
     b = b / norm(b)
 
-    x_gmres, c_gmres= gmres(A, b, L, R)
+    x_gmres, c_gmres= gmres(A, b, Pl=L, Pr=R, log=true)
     @fact c_gmres.isconverged --> true
     @fact norm(A*x_gmres - b) --> less_than(√eps(real(one(T))))
 
-    x_gmres, c_gmres = gmres(A, b, F; maxiter=1, restart=1)
+    x_gmres, c_gmres = gmres(A, b, Pl=F, maxiter=1, restart=1, log=true)
     @fact c_gmres.isconverged --> true
     @fact norm(A*x_gmres - b) --> less_than(√eps(real(one(T))))
 
-    x_gmres, c_gmres = gmres(A, b, 1, F; maxiter=1, restart=1)
+    x_gmres, c_gmres = gmres(A, b, Pl=1, Pr=F, maxiter=1, restart=1, log=true)
     @fact c_gmres.isconverged --> true
     @fact norm(A*x_gmres - b) --> less_than(√eps(real(one(T))))
     end
@@ -135,7 +135,7 @@ for T in (Float32, Float64, Complex64, Complex128)
     end
     b = b/norm(b)
 
-    x_idrs, c_idrs = idrs(A, b)
+    x_idrs, c_idrs = idrs(A, b, log=true)
     @fact c_idrs.isconverged --> true
     @fact norm(A*x_idrs - b) --> less_than(√eps(real(one(T))))
     end
@@ -151,7 +151,7 @@ for T in (Float32, Float64, Complex64, Complex128)
     end
     b = b/norm(b)
 
-    x_idrs, c_idrs = idrs(A, b; smoothing=true)
+    x_idrs, c_idrs = idrs(A, b; smoothing=true, log=true)
     @fact c_idrs.isconverged --> true
     @fact norm(A*x_idrs - b) --> less_than(√eps(real(one(T))))
     end
@@ -167,7 +167,7 @@ for T in (Float64, Complex128)
     end
     b = b / norm(b)
 
-    x_idrs, c_idrs= idrs(A, b)
+    x_idrs, c_idrs= idrs(A, b, log=true)
     @fact c_idrs.isconverged --> true
     @fact norm(A*x_idrs - b) --> less_than(√eps(real(one(T))))
     end
@@ -189,7 +189,7 @@ for T in (Float32, Float64, Complex64, Complex128)
     v = eigvals(A)
     mxv = maximum(v)
     mnv = minimum(v)
-    x_cheby, c_cheby= chebyshev(A, b, mxv+(mxv-mnv)/100, mnv-(mxv-mnv)/100, tol=tol, maxiter=10^5)
+    x_cheby, c_cheby= chebyshev(A, b, mxv+(mxv-mnv)/100, mnv-(mxv-mnv)/100, tol=tol, maxiter=10^5, log=true)
     @fact c_cheby.isconverged --> true
     @fact norm(A*x_cheby-b) --> less_than(tol)
     end
@@ -215,7 +215,7 @@ for T in (Float32, Float64, Complex64, Complex128)
 
     context("Power iteration") do
     eval_big = maximum(v) > abs(minimum(v)) ? maximum(v) : minimum(v)
-    eval_pow = eigvals_power(A; tol=sqrt(eps(real(one(T)))), maxiter=2000)[1].val
+    eval_pow = powm(A; tol=sqrt(eps(real(one(T)))), maxiter=2000)[1]
     @fact norm(eval_big-eval_pow) --> less_than(tol)
     end
 
@@ -225,13 +225,13 @@ for T in (Float32, Float64, Complex64, Complex128)
     # Perturb the eigenvalue by < 1/4 of the distance to the nearest eigenvalue
     eval_diff = min(abs(v[irnd]-eval_rand), abs(v[irnd+2]-eval_rand))
     σ = eval_rand + eval_diff/2*(rand()-.5)
-    eval_ii = eigvals_ii(A, σ; tol=sqrt(eps(real(one(T)))), maxiter=2000)[1].val
+    eval_ii = invpowm(A; shift=σ, tol=sqrt(eps(real(one(T)))), maxiter=2000)[1]
     @fact norm(eval_rand-eval_ii) --> less_than(tol)
     end
 
     #context("Rayleigh quotient iteration") do
     #XXX broken?
-    #l = eigvals_rqi(A, eigvals_rand, 2000, √eps()).val
+    #l = eigvals_rqi(A, eigvals_rand, 2000, √eps())[2]
     #@fact norm(eigvals_rand-l) --> less_than(tol)
     #end
 
@@ -251,14 +251,14 @@ import Base: *, size, eltype
 size(A::MyOp, i) = size(A.buf, i)
 eltype(A::MyOp) = eltype(A.buf)
 
-facts("eigvals_lanczos") do
+facts("eiglancz") do
 for T in (Float32, Float64)
     context("Matrix{$T}") do
     A = convert(Matrix{T}, randn(n,n))
     A = A + A' #Symmetric
     v = eigvals(A)
 
-    eval_lanczos, c_lanczos = eigvals_lanczos(A)
+    eval_lanczos, c_lanczos = eiglancz(A, log=true)
     @fact c_lanczos.isconverged --> true
     @fact norm(v - eval_lanczos) --> less_than(√eps(T))
     end
@@ -266,7 +266,7 @@ for T in (Float32, Float64)
     context("Op{$T}") do
         A = MyOp(convert(Matrix{T}, randn(5,5)) |> t -> t + t')
         v = eigvals(Symmetric(A.buf))
-        eval_lanczos, c_lanczos = eigvals_lanczos(A)
+        eval_lanczos, c_lanczos = eiglancz(A, log=true)
         @fact c_lanczos.isconverged --> true
         @fact norm(v - eval_lanczos) --> less_than(√eps(T))
     end

--- a/test/svdl.jl
+++ b/test/svdl.jl
@@ -12,12 +12,12 @@ for method in (:ritz, :harmonic) context("Thick restart with method=$method") do
 
         A = full(Diagonal(elty[1.0:n;]))
         q = convert(Vector{elty}, ones(n)/√n)
-        σ, L = svdl(A, ns, v0=q, tol=tol, reltol=tol, maxiter=n, method=method, vecs=:none)
+        σ, L = svdl(A, nsv=ns, v0=q, tol=tol, reltol=tol, maxiter=n, method=method, vecs=:none)
         @fact norm(σ - [n:-1.0:n-4;]) --> less_than(5^2*1e-5)
-        @fact_throws ArgumentError svdl(A, ns, v0=q, tol=tol, reltol=tol, maxiter=n, method=:fakemethod, vecs=:none)
+        @fact_throws ArgumentError svdl(A, nsv=ns, v0=q, tol=tol, reltol=tol, maxiter=n, method=:fakemethod, vecs=:none)
 
         #Check the singular vectors also
-        Σ, L = svdl(A, ns, v0=q, tol=tol, reltol=tol, maxiter=n, method=method, vecs=:both)
+        Σ, L = svdl(A, nsv=ns, v0=q, tol=tol, reltol=tol, maxiter=n, method=method, vecs=:both)
 
         #The vectors should have the structure
         # [ 0  0 ...  0 ]
@@ -40,7 +40,7 @@ for method in (:ritz, :harmonic) context("Thick restart with method=$method") do
 
         #Issue #55
         let
-            σ1, _ = svdl(A, 1, tol=tol, reltol=tol)
+            σ1, _ = svdl(A, nsv=1, tol=tol, reltol=tol)
             @fact abs(σ[1] - σ1[1]) --> less_than(2max(tol*σ[1], tol))
         end
     end
@@ -54,7 +54,7 @@ for method in (:ritz, :harmonic) context("Thick restart with method=$method") do
 
         A = convert(Matrix{elty}, randn(m,n))
         q = convert(Vector{elty}, randn(n))|>x->x/norm(x)
-        σ, L = svdl(A, k, k=l, v0=q, tol=1e-5, maxiter=30, method=method)
+        σ, L = svdl(A, nsv=k, k=l, v0=q, tol=1e-5, maxiter=30, method=method)
         @fact norm(σ - svdvals(A)[1:k]) --> less_than(k^2*1e-5)
     end
   end


### PR DESCRIPTION
Summary of changes:
- Remove `KrylovSubspace` type from method signatures
- Optional positional arguments are now keywords.
- New `log` keyword for all methods, if true returns solution else it returns the solution and the `ConvergenceHistory` object 
- `verbose` and `plot` keyword for all iterative methods. `plot` can only be set to true when `log` is also set
- Add UnicodePlots dependency
- Change names of the simple eigenvalue methods.
- `eigvals_lanczos` --> `eiglancz`
- Simple eigenvalue methods return a `Pair` instead of an `EigenPair`
- Change keyword name `ns` to `nsv` in svdl method
- Previous definition of `maxiter` in GMRES changed from number of macroiterations to number of total iterations
- Added docstrings for the new API
- Some reordering of the methods inside each file

Documentation is at the end of each file to allow easy browsing. Current mvps count might be wrong, should initial matvec products be counted or just the ones inside the loop?
