### PR TITLE
Shrink history when logging in addition to when plotting

### DIFF
--- a/src/cg.jl
+++ b/src/cg.jl
@@ -17,7 +17,8 @@ function cg!(x, A, b;
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     cg_method!(history, x, K, b; tol=tol, maxiter=maxiter, kwargs...)
-    plot && (shrink!(history); showplot(history))
+    (plot || log) && shrink!(history)
+    plot && showplot(history)
     log ? (x, history) : x
 end
 

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -19,7 +19,8 @@ function chebyshev!(x, A, b, λmin::Real, λmax::Real;
     history[:tol] = tol
     reserve!(history,:resnorm,maxiter)
     chebyshev_method!(history, x, K, b, λmin, λmax; tol=tol, maxiter=maxiter, kwargs...)
-    plot && (shrink!(history); showplot(history))
+    (plot || log) && shrink!(history)
+    plot && showplot(history)
     log ? (x, history) : x
 end
 

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -15,7 +15,8 @@ function gmres!(x, A, b;
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter*restart)
     gmres_method!(history, x, A, b; tol=tol, maxiter=maxiter, restart=restart, kwargs...)
-    plot && (shrink!(history); showplot(history))
+    (plot || log) && shrink!(history)
+    plot && showplot(history)
     log ? (x, history) : x
 end
 

--- a/src/idrs.jl
+++ b/src/idrs.jl
@@ -17,7 +17,8 @@ function idrs!(x, A, b;
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     idrs_method!(history, x, linsys_op, (A,), b, s, tol, maxiter; kwargs...)
-    plot && (shrink!(history); showplot(history))
+    (plot || log) && shrink!(history)
+    plot && showplot(history)
     log ? (x, history) : x
 end
 

--- a/src/lanczos.jl
+++ b/src/lanczos.jl
@@ -15,7 +15,8 @@ function eiglancz(A;
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     e1 = eiglancz_method(history, A; maxiter=maxiter, tol=tol, kwargs...)
-    plot && (shrink!(history); showplot(history))
+    (plot || log) && shrink!(history)
+    plot && showplot(history)
     log ? (e1, history) : e1
 end
 

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -22,7 +22,8 @@ function lsmr!(x, A, b;
     copy!(btmp, b)
     v, h, hbar = similar(x, T), similar(x, T), similar(x, T)
     lsmr_method!(history, x, A, btmp, v, h, hbar; maxiter=maxiter, kwargs...)
-    plot && (shrink!(history); showplot(history))
+    (plot || log) && shrink!(history)
+    plot && showplot(history)
     log ? (x, history) : x
 end
 

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -17,7 +17,8 @@ function lsqr!(x, A, b;
     history = ConvergenceHistory(partial=!log)
     reserve!(history,[:resnorm,:anorm,:rnorm,:cnorm],maxiter)
     lsqr_method!(history, x, A, b; maxiter=maxiter, kwargs...)
-    plot && (shrink!(history); showplot(history))
+    (plot || log) && shrink!(history)
+    plot && showplot(history)
     log ? (x, history) : x
 end
 

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -17,7 +17,8 @@ function powm(A;
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     eig, v = powm_method!(history, K; tol=tol, maxiter=maxiter, kwargs...)
-    plot && (shrink!(history); showplot(history))
+    (plot || log) && shrink!(history)
+    plot && showplot(history)
     log ? (eig, v, history) : (eig, v)
 end
 
@@ -62,7 +63,8 @@ function invpowm(A;
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     eig, v = invpowm_method!(history, K, shift; tol=tol, maxiter=maxiter, kwargs...)
-    plot && (shrink!(history); showplot(history))
+    (plot || log) && shrink!(history)
+    plot && showplot(history)
     log ? (eig, v, history) : (eig, v)
 end
 
@@ -109,7 +111,8 @@ function rqi(A;
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     eig, v = rqi_method!(history, K, shift; tol=tol, maxiter=maxiter, kwargs...)
-    plot && (shrink!(history); showplot(history))
+    (plot || log) && shrink!(history)
+    plot && showplot(history)
     log ? (eig, v, history) : (eig, v)
 end
 

--- a/src/stationary.jl
+++ b/src/stationary.jl
@@ -17,7 +17,8 @@ function jacobi!(x, A::AbstractMatrix, b;
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     jacobi_method!(history, x, A, b; tol=tol, maxiter=maxiter, kwargs...)
-    plot && (shrink!(history); showplot(history))
+    (plot || log) && shrink!(history)
+    plot && showplot(history)
     log ? (x, history) : x
 end
 
@@ -72,7 +73,8 @@ function gauss_seidel!(x, A::AbstractMatrix, b;
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     gauss_seidel_method!(history, x, A, b; tol=tol, maxiter=maxiter, kwargs...)
-    plot && (shrink!(history); showplot(history))
+    (plot || log) && shrink!(history)
+    plot && showplot(history)
     log ? (x, history) : x
 end
 
@@ -130,7 +132,8 @@ function sor!(x, A::AbstractMatrix, b, ω::Real;
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     sor_method!(history, x, A, b, ω; tol=tol, maxiter=maxiter, kwargs...)
-    plot && (shrink!(history); showplot(history))
+    (plot || log) && shrink!(history)
+    plot && showplot(history)
     log ? (x, history) : x
 end
 
@@ -191,7 +194,8 @@ function ssor!(x, A::AbstractMatrix, b, ω::Real;
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     ssor_method!(history, x, A, b, ω; tol=tol, maxiter=maxiter, kwargs...)
-    plot && (shrink!(history); showplot(history))
+    (plot || log) && shrink!(history)
+    plot && showplot(history)
     log ? (x, history) : x
 end
 

--- a/src/svdl.jl
+++ b/src/svdl.jl
@@ -159,7 +159,8 @@ function svdl(A;
     reserve!(Bs_type, history,:Bs, maxiter)
     reserve!(history,:betas, maxiter)
     X, L = svdl_method!(history, A, nsv; k=k, tol=tol, maxiter=maxiter, method=method, kwargs...)
-    plot && (shrink!(history); showplot(history))
+    (plot || log) && shrink!(history)
+    plot && showplot(history)
     log ? (X, L, history) : (X, L)
 end
 


### PR DESCRIPTION
This patches correctly truncates convergence history so that it only contains valid values. Previously, history was only truncated when plotting (and not when logging).