### PR TITLE
Update README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Iterative Solvers
 
-[![license](https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000)](https://github.com/JuliaLang/IterativeSolvers.jl/blob/master/LICENSE)
-[![Build Status on Linux](https://travis-ci.org/JuliaLang/IterativeSolvers.jl.svg?branch=master)](https://travis-ci.org/JuliaLang/IterativeSolvers.jl)
-[![Coverage Status](https://coveralls.io/repos/JuliaLang/IterativeSolvers.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaLang/IterativeSolvers.jl?branch=master)
-[![codecov.io](https://codecov.io/github/JuliaLang/IterativeSolvers.jl/coverage.svg?branch=master)](https://codecov.io/github/JuliaLang/IterativeSolvers.jl?branch=master)
+[![license](https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000)](https://github.com/JuliaMath/IterativeSolvers.jl/blob/master/LICENSE)
+[![Build Status on Linux](https://travis-ci.org/JuliaMath/IterativeSolvers.jl.svg?branch=master)](https://travis-ci.org/JuliaMath/IterativeSolvers.jl)
+[![Coverage Status](https://coveralls.io/repos/JuliaMath/IterativeSolvers.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaMath/IterativeSolvers.jl?branch=master)
+[![codecov.io](https://codecov.io/github/JuliaMath/IterativeSolvers.jl/coverage.svg?branch=master)](https://codecov.io/github/JuliaMath/IterativeSolvers.jl?branch=master)
 [![IterativeSolvers](http://pkg.julialang.org/badges/IterativeSolvers_0.5.svg)](http://pkg.julialang.org/?pkg=IterativeSolvers&ver=0.5)
 
 `IterativeSolvers` is a [Julia](http://julialang.org) package that provides iterative algorithms for solving linear systems, eigensystems, and singular value problems.
@@ -22,8 +22,8 @@ Pkg.add("IterativeSolvers")
 
 ## Status
 
-- [Issue #1](https://github.com/JuliaLang/IterativeSolvers.jl/issues/1) documents the implementation roadmap for iterative solvers.
+- [Issue #1](https://github.com/JuliaMath/IterativeSolvers.jl/issues/1) documents the implementation roadmap for iterative solvers.
 
 - The interfaces between the various algorithms are still in flux, but aim to be consistent.
 
-- [Issue #33](https://github.com/JuliaLang/IterativeSolvers.jl/issues/33) documents the implementation roadmap for randomized algorithms.
+- [Issue #33](https://github.com/JuliaMath/IterativeSolvers.jl/issues/33) documents the implementation roadmap for randomized algorithms.


### PR DESCRIPTION
Some of the README links still went to JuliaLang, which caused the badges to be broken or out of date.