### PR TITLE
WIP: Attempting to integrate linear maps in IterativeSolvers

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ julia 0.5-
 UnicodePlots
 RecipesBase
 SugarBLAS
+LinearMaps

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,6 +1,8 @@
 import  Base: eltype, eps, length, ndims, real, size, *, \,
         A_mul_B!, Ac_mul_B, Ac_mul_B!
 
+import LinearMaps.FunctionMap
+
 export  A_mul_B
 
 # Improve readability of iterative methods
@@ -10,17 +12,22 @@ export  A_mul_B
 #### Type-handling
 """
     Adivtype(A, b)
+If A is a function map then:
+`typeof(one(eltype(b)))`
 Determine type of the division of an element of `b` against an element of `A`:
 `typeof(one(eltype(b))/one(eltype(A)))`
 """
-Adivtype(A, b) = typeof(one(eltype(b))/one(eltype(A)))
+Adivtype(A, b) = isa(A, FunctionMap) ? typeof(one(eltype(b))) : typeof(one(eltype(b))/one(eltype(A)))
 
 """
     Amultype(A, x)
+If A is a function map then:
+`typeof(one(eltype(b)))`
 Determine type of the multiplication of an element of `b` with an element of `A`:
 `typeof(one(eltype(A))*one(eltype(x)))`
 """
-Amultype(A, x) = typeof(one(eltype(A))*one(eltype(x)))
+Amultype(A, x) = isa(A, FunctionMap) ? typeof(one(eltype(b))) :typeof(one(eltype(A))*one(eltype(x)))
+
 if VERSION < v"0.4.0-dev+6068"
     real{T<:Real}(::Type{Complex{T}}) = T
     real{T<:Real}(::Type{T}) = T

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,8 +1,6 @@
 import  Base: eltype, eps, length, ndims, real, size, *, \,
         A_mul_B!, Ac_mul_B, Ac_mul_B!
 
-import LinearMaps.FunctionMap
-
 export  A_mul_B
 
 using   LinearMaps
@@ -19,7 +17,7 @@ If A is a function map then:
 Determine type of the division of an element of `b` against an element of `A`:
 `typeof(one(eltype(b))/one(eltype(A)))`
 """
-Adivtype(A, b) = isa(A, FunctionMap) ? typeof(one(eltype(b))) : typeof(one(eltype(b))/one(eltype(A)))
+Adivtype(A, b) = typeof(one(eltype(b))/one(eltype(A)))
 
 """
     Amultype(A, x)
@@ -28,7 +26,7 @@ If A is a function map then:
 Determine type of the multiplication of an element of `b` with an element of `A`:
 `typeof(one(eltype(A))*one(eltype(x)))`
 """
-Amultype(A, x) = isa(A, FunctionMap) ? typeof(one(eltype(b))) :typeof(one(eltype(A))*one(eltype(x)))
+Amultype(A, x) = typeof(one(eltype(A))*one(eltype(x)))
 
 if VERSION < v"0.4.0-dev+6068"
     real{T<:Real}(::Type{Complex{T}}) = T

--- a/src/common.jl
+++ b/src/common.jl
@@ -12,8 +12,6 @@ using   LinearMaps
 #### Type-handling
 """
     Adivtype(A, b)
-If A is a function map then:
-`typeof(one(eltype(b)))`
 Determine type of the division of an element of `b` against an element of `A`:
 `typeof(one(eltype(b))/one(eltype(A)))`
 """
@@ -21,8 +19,6 @@ Adivtype(A, b) = typeof(one(eltype(b))/one(eltype(A)))
 
 """
     Amultype(A, x)
-If A is a function map then:
-`typeof(one(eltype(b)))`
 Determine type of the multiplication of an element of `b` with an element of `A`:
 `typeof(one(eltype(A))*one(eltype(x)))`
 """

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,6 +1,8 @@
 import  Base: eltype, eps, length, ndims, real, size, *,
         A_mul_B!, Ac_mul_B, Ac_mul_B!
 
+using   LinearMaps
+
 export  A_mul_B
 
 #### Type-handling

--- a/src/rlinalg.jl
+++ b/src/rlinalg.jl
@@ -326,7 +326,7 @@ immutable srft{T<:Integer}
     l :: T
 end
 
-(*)(A::LinearMap, B::srft) = error("method only defined to avoid ambiguity. If you need this method please open a pull request")
+#(*)(A::LinearMap, B::srft) = error("method only defined to avoid ambiguity. If you need this method please open a pull request")
 
 """
     *

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -3,3 +3,4 @@ MAT
 MatrixMarket
 Plots
 UnicodePlots
+LinearMaps

--- a/test/common.jl
+++ b/test/common.jl
@@ -37,25 +37,25 @@ context("Linear operator defined as a function") do
     Atimesb = [b[end]; b[1:end-1]]
     Aptimesb = [b[2:end]; b[1]]
 
-    A = LinearMap(shiftback!, Int, 5; ismutating=true)
+    A = LinearMap(shiftback!, 5, 5, Int; ismutating=true)
     @fact eltype(A) --> Int
     @fact size(A) --> (5,5)
     @fact size(A,1) --> 5
     @fact size(A,2) --> 5
-    #@fact ndims(A) --> 2
-    #@fact length(A) --> 25
+    @fact ndims(A) --> 2
+    @fact length(A) --> 25
     @fact A*b --> Atimesb
 
     output = similar(b)
     @fact A_mul_B!(output, A, b) --> Atimesb
     @fact_throws A'*b
 
-    A = LinearMap(shiftback!, Int, 5; ftranspose=shiftfwd!, ismutating=true)
+    A = LinearMap(shiftback!, shiftfwd!, 5, Int; ismutating=true)
     @fact eltype(A) --> Int
     @fact size(A) --> (5,5)
     @fact size(A,1) --> 5
     @fact size(A,2) --> 5
-    #@fact length(A) --> 25
+    @fact length(A) --> 25
     @fact A*b --> Atimesb
 
     output = similar(b)

--- a/test/common.jl
+++ b/test/common.jl
@@ -37,7 +37,7 @@ context("Linear operator defined as a function") do
     Atimesb = [b[end]; b[1:end-1]]
     Aptimesb = [b[2:end]; b[1]]
 
-    A = LinearMap(shiftback!, 5, 5, Int; ismutating=true)
+    A = LinearMap(shiftback!, Int, 5; ismutating=true)
     @fact eltype(A) --> Int
     @fact size(A) --> (5,5)
     @fact size(A,1) --> 5
@@ -50,7 +50,7 @@ context("Linear operator defined as a function") do
     @fact A_mul_B!(output, A, b) --> Atimesb
     @fact_throws A'*b
 
-    A = LinearMap(shiftback!, shiftfwd!, 5, Int; ismutating=true)
+    A = LinearMap(shiftback!, Int, 5; ftranspose=shiftfwd!, ismutating=true)
     @fact eltype(A) --> Int
     @fact size(A) --> (5,5)
     @fact size(A,1) --> 5

--- a/test/lsqr.jl
+++ b/test/lsqr.jl
@@ -21,7 +21,7 @@ context("SOL test") do
     function lsqrSOLtest( m, n, damp )
         fmul  = (out, b) -> Aprodxxx!(out,b,1,m,n)
         fcmul = (out, b) -> Aprodxxx!(out,b,2,m,n)
-        A = LinearMap(fmul, Int, m, n; ftranspose=fcmul, ismutating=true)
+        A = LinearMap(fmul, fcmul, m, n, Int; ismutating=true)
         xtrue = n:-1:1
         b = float(A*xtrue)
         x = lsqr(A, b, atol = 1e-6, btol = 1e-6, conlim = 1e10, maxiter = 10n)

--- a/test/lsqr.jl
+++ b/test/lsqr.jl
@@ -21,7 +21,7 @@ context("SOL test") do
     function lsqrSOLtest( m, n, damp )
         fmul  = (out, b) -> Aprodxxx!(out,b,1,m,n)
         fcmul = (out, b) -> Aprodxxx!(out,b,2,m,n)
-        A = LinearMap(fmul, fcmul, m, n, Int; ismutating=true)
+        A = LinearMap(fmul, Int, m, n; ftranspose=fcmul, ismutating=true)
         xtrue = n:-1:1
         b = float(A*xtrue)
         x = lsqr(A, b, atol = 1e-6, btol = 1e-6, conlim = 1e10, maxiter = 10n)


### PR DESCRIPTION
@jiahao 
LinearMap approach is working for lsqr as follows. It is using the function to calculate L*u instead of calculating it as a matrix multiplication. I have made some changes to LinearMaps.jl also so its current version won't work.
```
function laplace_times(next_u, u)
    for i in 2:length(u)-1
        next_u[i] = -u[i-1]+2u[i]-u[i+1]
    end
end

L = LinearMap(laplace_times, 4, ismutating=true)
b = rand(4)
lsqr(L, b)
4-element Array{Float64,1}:
 -0.28294 
  0.278895
  0.291031
 -0.286985
```