### PR TITLE
Revert the methods added in #84

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5-
+julia 0.5
 
 UnicodePlots
 RecipesBase

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -47,7 +47,7 @@ function cg_method!(log::ConvergenceHistory, x, K, b;
         push!(log,:resnorm,resnorm)
         verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         resnorm < tol && break
-        z = Pl\r
+        z = isa(Pl, Function) ? Pl(r) : Pl\r
         oldγ = γ
         γ = dot(r, z)
         β = γ/oldγ

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -32,7 +32,7 @@ function cg_method!(log::ConvergenceHistory, x, K, b;
     verbose && @printf("=== cg ===\n%4s\t%7s\n","iter","resnorm")
     tol = tol * norm(b)
     r = b - nextvec(K)
-    z = isa(Pl, Function) ? Pl(r) : Pl\r
+    z = solve(Pl,r)
     p = copy(z)
     γ = dot(r, z)
     for iter=1:maxiter
@@ -47,7 +47,7 @@ function cg_method!(log::ConvergenceHistory, x, K, b;
         push!(log,:resnorm,resnorm)
         verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         resnorm < tol && break
-        z = isa(Pl, Function) ? Pl(r) : Pl\r
+        z = solve(Pl,r)
         oldγ = γ
         γ = dot(r, z)
         β = γ/oldγ

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -44,7 +44,7 @@ function chebyshev_method!(
 	c::eltype(b) = (λmax - λmin)/2
 	for iter = 1:maxiter
         nextiter!(log, mvps=1)
-		z = Pr\r
+		z = solve(Pr,r)
 		if iter == 1
 			p = z
 			α = 2/d

--- a/src/common.jl
+++ b/src/common.jl
@@ -43,6 +43,13 @@ end
 
 #### Numerics
 """
+    solve(A,b)
+Solve `A\b` with a direct solver. When `A` is a function `A(b)` is dispatched instead.
+"""
+solve(A::Function,b) = A(b)
+solve(A,b) = A\b
+
+"""
     initrand!(v)
 Overwrite `v` with a random unitary vector of the same length.
 """

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,11 +1,7 @@
-import  Base: eltype, eps, length, ndims, real, size, *, \,
+import  Base: eltype, eps, length, ndims, real, size, *,
         A_mul_B!, Ac_mul_B, Ac_mul_B!
 
 export  A_mul_B
-
-# Improve readability of iterative methods
-\(f::Function, b) = f(b)
-*(f::Function, b) = f(b)
 
 #### Type-handling
 """

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -114,7 +114,7 @@ function gmres_method!(log::ConvergenceHistory, x, A, b;
 
         @eval a = $(VERSION < v"0.4-" ? Triangular(H[1:N, 1:N], :U) \ s[1:N] : UpperTriangular(H[1:N, 1:N]) \ s[1:N])
         w = a[1:N] * K
-        @blas! x = Pr\w #Right preconditioner
+        @blas! x = isa(Pr, Function) ? Pr(w) : Pr\w #Right preconditioner
 
         if (rho<tol) | ((macroiter-1)*restart+N >= maxiter)
             setconv(log, rho<tol)

--- a/src/krylov.jl
+++ b/src/krylov.jl
@@ -102,6 +102,10 @@ function nextvec(K::KrylovSubspace)
     K.mvps += 1
     K.A*lastvec(K)
 end
+function nextvec{T,OpT<:Function}(K::KrylovSubspace{T,OpT})
+    K.mvps += 1
+    K.A(lastvec(K))
+end
 
 size(K::KrylovSubspace) = length(K.v)
 function size(K::KrylovSubspace, n::Int)


### PR DESCRIPTION
This is "type piracy" - extending a Base method on a signature of all Base types. Base's method tables are shared global mutable state, doing things like this can change the behavior of completely unrelated code when this package is imported.

nightly travis failure is not new, same happened at https://travis-ci.org/JuliaMath/IterativeSolvers.jl/jobs/204028681