### PR TITLE
Update, not reset the solution at restart

### DIFF
--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -114,7 +114,7 @@ function gmres_method!(log::ConvergenceHistory, x, A, b;
 
         @eval a = $(VERSION < v"0.4-" ? Triangular(H[1:N, 1:N], :U) \ s[1:N] : UpperTriangular(H[1:N, 1:N]) \ s[1:N])
         w = a[1:N] * K
-        @blas! x = solve(Pr,w) #Right preconditioner
+        @blas! x += solve(Pr,w) #Right preconditioner
 
         if (rho<tol) | ((macroiter-1)*restart+N >= maxiter)
             setconv(log, rho<tol)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,10 @@ for T in (Float32, Float64, Complex64, Complex128)
     F = lufact(A)
     b = b/norm(b)
 
+    # Test optimality condition: residual should be non-increasing
+    x_gmres, c_gmres = gmres(A, b, log = true, restart = 3, maxiter = 10);
+    @fact all(diff(c_gmres[:resnorm]) .<= 0.0) --> true
+
     x_gmres, c_gmres = gmres(A, b, Pl=L, Pl=R, log=true)
     @fact c_gmres.isconverged --> true
     @fact norm(A*x_gmres - b) --> less_than(√eps(real(one(T))))
@@ -102,6 +106,10 @@ for T in (Float64, Complex128)
     end
     F = lufact(A)
     b = b / norm(b)
+
+    # Test optimality condition: residual should be non-increasing
+    x_gmres, c_gmres = gmres(A, b, log = true, restart = 3, maxiter = 10);
+    @fact all(diff(c_gmres[:resnorm]) .<= 0.0) --> true
 
     x_gmres, c_gmres= gmres(A, b, Pl=L, Pr=R, log=true)
     @fact c_gmres.isconverged --> true


### PR DESCRIPTION
The current restarted GMRES implementation has a bug #109 where the approximate solution is overwritten rather than incremented at restart.

Below is the convergence history for a simple 1D Poisson matrix. Since GMRES selects the minimal residual from the Krylov search space, the normed residual should not increase like this.

![not_optimal](https://cloud.githubusercontent.com/assets/194764/26355304/6bf582f8-3fc8-11e7-8962-7418333db6a8.png)

Here the residual for the same problem after the fix:

![optimal](https://cloud.githubusercontent.com/assets/194764/26355303/6beba3fa-3fc8-11e7-9ffc-ef0ac757195b.png)

To reproduce the above:

```julia
poisson1d(n) = spdiagm( (ones(n - 1), -2 * ones(n), ones(n - 1)), (-1, 0, 1) )
A = poisson1d(200)
x = rand(200)
b = A * x
x, history = gmres(A, b; log = true, maxiter = 100, restart = 20)
plot(history.data[:resnorm], yscale = :log10)
```
