### PR TITLE
Fix docs typo

### DIFF
--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -173,7 +173,7 @@ $arg
 
 `Pl = 1`: left preconditioner of the method.
 
-`Pr = 1`: left preconditioner of the method.
+`Pr = 1`: right preconditioner of the method.
 
 `tol::Real = sqrt(eps())`: stopping tolerance.
 


### PR DESCRIPTION
`Pr` are the right preconditioners, but the line above was copied. I accidentally pushed the other commit for this to master, but don't think it's worth reverting since it's just a simple docs typo fix. But if this is wrong, feel free to revert that.