### PR TITLE
cg.jl memory leak fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # mkdocs site
 /site
 /docs/build
+*.mem

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ julia 0.5-
 UnicodePlots
 RecipesBase
 SugarBLAS
+LinearMaps

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -52,7 +52,7 @@ function cg_method!(log::ConvergenceHistory, x, K, b;
         push!(log,:resnorm,resnorm)
         verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         resnorm < tol && break
-        z = solve(Pl,r)
+        solve!(z,Pl,r)
         oldγ = γ
         γ = dot(r, z)
         β = γ/oldγ

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -36,13 +36,14 @@ function cg_method!(log::ConvergenceHistory, x, K, b;
     verbose && @printf("=== cg ===\n%4s\t%7s\n","iter","resnorm")
     tol = tol * norm(b)
     r = b - nextvec(K)
+    q = zeros(r)
     z = solve(Pl,r)
     p = copy(z)
     γ = dot(r, z)
     for iter=1:maxiter
         nextiter!(log, mvps=1)
         append!(K, p)
-        q = nextvec(K)
+        nextvec!(q, K)
         α = γ/dot(p, q)
         # α>=0 || throw(PosSemidefException("α=$α"))
         @blas! x += α*p

--- a/src/common.jl
+++ b/src/common.jl
@@ -50,7 +50,13 @@ end
 Solve `A\b` with a direct solver. When `A` is a function `A(b)` is dispatched instead.
 """
 solve(A::Function,b) = A(b)
+
 solve(A,b) = A\b
+
+solve!{T}(out::AbstractArray{T},A::Int,b::AbstractArray{T}) = scale!(out,b, 1/A)
+
+solve!{T}(out::AbstractArray{T},A,b::AbstractArray{T}) = A_ldiv_B!(out,A,b)
+solve!{T}(out::AbstractArray{T},A::Function,b::AbstractArray{T}) = copy!(out,A(b))
 
 """
     initrand!(v)

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,6 +1,8 @@
 import  Base: eltype, eps, length, ndims, real, size, *, \,
         A_mul_B!, Ac_mul_B, Ac_mul_B!
 
+import LinearMaps.FunctionMap
+
 export  A_mul_B
 
 # Improve readability of iterative methods
@@ -10,17 +12,22 @@ export  A_mul_B
 #### Type-handling
 """
     Adivtype(A, b)
+If A is a function map then:
+`typeof(one(eltype(b)))`
 Determine type of the division of an element of `b` against an element of `A`:
 `typeof(one(eltype(b))/one(eltype(A)))`
 """
-Adivtype(A, b) = typeof(one(eltype(b))/one(eltype(A)))
+Adivtype(A, b) = isa(A, FunctionMap) ? typeof(one(eltype(b))) : typeof(one(eltype(b))/one(eltype(A)))
 
 """
     Amultype(A, x)
+If A is a function map then:
+`typeof(one(eltype(b)))`
 Determine type of the multiplication of an element of `b` with an element of `A`:
 `typeof(one(eltype(A))*one(eltype(x)))`
 """
-Amultype(A, x) = typeof(one(eltype(A))*one(eltype(x)))
+Amultype(A, x) = isa(A, FunctionMap) ? typeof(one(eltype(b))) :typeof(one(eltype(A))*one(eltype(x)))
+
 if VERSION < v"0.4.0-dev+6068"
     real{T<:Real}(::Type{Complex{T}}) = T
     real{T<:Real}(::Type{T}) = T

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,8 +1,6 @@
 import  Base: eltype, eps, length, ndims, real, size, *, \,
         A_mul_B!, Ac_mul_B, Ac_mul_B!
 
-import LinearMaps.FunctionMap
-
 export  A_mul_B
 
 using   LinearMaps
@@ -19,7 +17,7 @@ If A is a function map then:
 Determine type of the division of an element of `b` against an element of `A`:
 `typeof(one(eltype(b))/one(eltype(A)))`
 """
-Adivtype(A, b) = isa(A, FunctionMap) ? typeof(one(eltype(b))) : typeof(one(eltype(b))/one(eltype(A)))
+Adivtype(A, b) = typeof(one(eltype(b))/one(eltype(A)))
 
 """
     Amultype(A, x)
@@ -28,7 +26,7 @@ If A is a function map then:
 Determine type of the multiplication of an element of `b` with an element of `A`:
 `typeof(one(eltype(A))*one(eltype(x)))`
 """
-Amultype(A, x) = isa(A, FunctionMap) ? typeof(one(eltype(b))) :typeof(one(eltype(A))*one(eltype(x)))
+Amultype(A, x) = typeof(one(eltype(A))*one(eltype(x)))
 
 if VERSION < v"0.4.0-dev+6068"
     real{T<:Real}(::Type{Complex{T}}) = T

--- a/src/common.jl
+++ b/src/common.jl
@@ -12,8 +12,6 @@ using   LinearMaps
 #### Type-handling
 """
     Adivtype(A, b)
-If A is a function map then:
-`typeof(one(eltype(b)))`
 Determine type of the division of an element of `b` against an element of `A`:
 `typeof(one(eltype(b))/one(eltype(A)))`
 """
@@ -21,8 +19,6 @@ Adivtype(A, b) = typeof(one(eltype(b))/one(eltype(A)))
 
 """
     Amultype(A, x)
-If A is a function map then:
-`typeof(one(eltype(b)))`
 Determine type of the multiplication of an element of `b` with an element of `A`:
 `typeof(one(eltype(A))*one(eltype(x)))`
 """

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,6 +1,8 @@
 import  Base: eltype, eps, length, ndims, real, size, *,
         A_mul_B!, Ac_mul_B, Ac_mul_B!
 
+using   LinearMaps
+
 export  A_mul_B
 
 #### Type-handling

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -7,8 +7,8 @@ export gmres, gmres!
 gmres(A, b; kwargs...) = gmres!(zerox(A,b), A, b; kwargs...)
 
 function gmres!(x, A, b;
-    tol=sqrt(eps(typeof(real(b[1])))), restart::Int=min(20,length(b)),
-    maxiter::Int=restart, plot::Bool=false, log::Bool=false, kwargs...
+    tol = sqrt(eps(typeof(real(b[1])))), restart::Int=min(20,length(b)),
+    maxiter::Int = restart, plot::Bool=false, log::Bool=false, kwargs...
     )
     (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial=!log, restart=restart)
@@ -26,7 +26,7 @@ end
 
 #One Arnoldi iteration
 #Optionally takes a truncation parameter l
-function arnoldi!(K::KrylovSubspace, w; l=K.order)
+function arnoldi(K::KrylovSubspace, w; l=K.order)
     v = nextvec(K)
     w = copy(v)
     n = min(length(K.v), l)
@@ -86,7 +86,7 @@ function gmres_method!(log::ConvergenceHistory, x, A, b;
         for j = 1:restart
             nextiter!(log, mvps=1)
             #Calculate next orthonormal basis vector in the Krylov subspace
-            H[1:j+1, j] = arnoldi!(K, w)
+            H[1:j+1, j] = arnoldi(K, w)
 
             #Update QR factorization of H
             #The Q is stored as a series of Givens rotations in J

--- a/src/krylov.jl
+++ b/src/krylov.jl
@@ -84,6 +84,7 @@ Get last vector computed in the Krylov subspace `K`.
 `::Vector`: last vector.
 """
 lastvec(K::KrylovSubspace) = K.v[end]
+lastvec!(out, K::KrylovSubspace) = copy!(out, K.v[end])
 
 """
     nextvec(K)
@@ -105,6 +106,15 @@ end
 function nextvec{T,OpT<:Function}(K::KrylovSubspace{T,OpT})
     K.mvps += 1
     K.A(lastvec(K))
+end
+
+function nextvec!{T}(out::AbstractArray{T}, K::KrylovSubspace{T})
+    K.mvps += 1
+    Base.A_mul_B!(out, K.A, lastvec(K))
+end
+function nextvec!{T,OpT<:Function}(out::AbstractArray{T}, K::KrylovSubspace{T,OpT})
+    K.mvps += 1
+    copy!(out, K.A(lastvec(K)))
 end
 
 size(K::KrylovSubspace) = length(K.v)

--- a/src/rlinalg.jl
+++ b/src/rlinalg.jl
@@ -326,7 +326,7 @@ immutable srft{T<:Integer}
     l :: T
 end
 
-(*)(A::LinearMap, B::srft) = error("method only defined to avoid ambiguity. If you need this method please open a pull request")
+#(*)(A::LinearMap, B::srft) = error("method only defined to avoid ambiguity. If you need this method please open a pull request")
 
 """
     *

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -3,3 +3,4 @@ MAT
 MatrixMarket
 Plots
 UnicodePlots
+LinearMaps

--- a/test/common.jl
+++ b/test/common.jl
@@ -37,25 +37,25 @@ context("Linear operator defined as a function") do
     Atimesb = [b[end]; b[1:end-1]]
     Aptimesb = [b[2:end]; b[1]]
 
-    A = LinearMap(shiftback!, Int, 5; ismutating=true)
+    A = LinearMap(shiftback!, 5, 5, Int; ismutating=true)
     @fact eltype(A) --> Int
     @fact size(A) --> (5,5)
     @fact size(A,1) --> 5
     @fact size(A,2) --> 5
-    #@fact ndims(A) --> 2
-    #@fact length(A) --> 25
+    @fact ndims(A) --> 2
+    @fact length(A) --> 25
     @fact A*b --> Atimesb
 
     output = similar(b)
     @fact A_mul_B!(output, A, b) --> Atimesb
     @fact_throws A'*b
 
-    A = LinearMap(shiftback!, Int, 5; ftranspose=shiftfwd!, ismutating=true)
+    A = LinearMap(shiftback!, shiftfwd!, 5, Int; ismutating=true)
     @fact eltype(A) --> Int
     @fact size(A) --> (5,5)
     @fact size(A,1) --> 5
     @fact size(A,2) --> 5
-    #@fact length(A) --> 25
+    @fact length(A) --> 25
     @fact A*b --> Atimesb
 
     output = similar(b)

--- a/test/common.jl
+++ b/test/common.jl
@@ -37,7 +37,7 @@ context("Linear operator defined as a function") do
     Atimesb = [b[end]; b[1:end-1]]
     Aptimesb = [b[2:end]; b[1]]
 
-    A = LinearMap(shiftback!, 5, 5, Int; ismutating=true)
+    A = LinearMap(shiftback!, Int, 5; ismutating=true)
     @fact eltype(A) --> Int
     @fact size(A) --> (5,5)
     @fact size(A,1) --> 5
@@ -50,7 +50,7 @@ context("Linear operator defined as a function") do
     @fact A_mul_B!(output, A, b) --> Atimesb
     @fact_throws A'*b
 
-    A = LinearMap(shiftback!, shiftfwd!, 5, Int; ismutating=true)
+    A = LinearMap(shiftback!, Int, 5; ftranspose=shiftfwd!, ismutating=true)
     @fact eltype(A) --> Int
     @fact size(A) --> (5,5)
     @fact size(A,1) --> 5

--- a/test/lsqr.jl
+++ b/test/lsqr.jl
@@ -21,7 +21,7 @@ context("SOL test") do
     function lsqrSOLtest( m, n, damp )
         fmul  = (out, b) -> Aprodxxx!(out,b,1,m,n)
         fcmul = (out, b) -> Aprodxxx!(out,b,2,m,n)
-        A = LinearMap(fmul, Int, m, n; ftranspose=fcmul, ismutating=true)
+        A = LinearMap(fmul, fcmul, m, n, Int; ismutating=true)
         xtrue = n:-1:1
         b = float(A*xtrue)
         x = lsqr(A, b, atol = 1e-6, btol = 1e-6, conlim = 1e10, maxiter = 10n)

--- a/test/lsqr.jl
+++ b/test/lsqr.jl
@@ -21,7 +21,7 @@ context("SOL test") do
     function lsqrSOLtest( m, n, damp )
         fmul  = (out, b) -> Aprodxxx!(out,b,1,m,n)
         fcmul = (out, b) -> Aprodxxx!(out,b,2,m,n)
-        A = LinearMap(fmul, fcmul, m, n, Int; ismutating=true)
+        A = LinearMap(fmul, Int, m, n; ftranspose=fcmul, ismutating=true)
         xtrue = n:-1:1
         b = float(A*xtrue)
         x = lsqr(A, b, atol = 1e-6, btol = 1e-6, conlim = 1e10, maxiter = 10n)


### PR DESCRIPTION
cg.jl had several memory leaks arising from https://github.com/JuliaMath/IterativeSolvers.jl/blob/master/src/cg.jl#L45
and 
https://github.com/JuliaMath/IterativeSolvers.jl/blob/master/src/cg.jl#L54.
``` julia
julia> @time x = cg(A, rhs; maxiter=2000);
  0.073056 seconds (12.04 k allocations: 31.635 MB, 14.14% gc time)
```
In this PR I have defined mutating functions for these functionalities and now we have
``` julia
julia> @time cg(A, rhs; maxiter=2000);
  0.051681 seconds (8.04 k allocations: 714.328 KB)
```

Please note that I have found many such areas of optimizations in gmres.jl, lancoz.jl etc. but due to want of time I won't be able to address those issues. 
Maybe @haampie can fix these during the summer.