### PR TITLE
reduced memory allocations to optimize cg.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # mkdocs site
 /site
 /docs/build
+*.mem

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -51,7 +51,7 @@ function cg_method!(log::ConvergenceHistory, x, K, b;
         push!(log,:resnorm,resnorm)
         verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
         resnorm < tol && break
-        z = solve(Pl,r)
+        solve!(z,Pl,r)
         oldγ = γ
         γ = dot(r, z)
         β = γ/oldγ

--- a/src/common.jl
+++ b/src/common.jl
@@ -44,7 +44,13 @@ end
 Solve `A\b` with a direct solver. When `A` is a function `A(b)` is dispatched instead.
 """
 solve(A::Function,b) = A(b)
+
 solve(A,b) = A\b
+
+solve!{T}(out::AbstractArray{T},A::Int,b::AbstractArray{T}) = scale!(out,b, 1/A)
+
+solve!{T}(out::AbstractArray{T},A,b::AbstractArray{T}) = A_ldiv_B!(out,A,b)
+solve!{T}(out::AbstractArray{T},A::Function,b::AbstractArray{T}) = copy!(out,A(b))
 
 """
     initrand!(v)

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -7,8 +7,8 @@ export gmres, gmres!
 gmres(A, b; kwargs...) = gmres!(zerox(A,b), A, b; kwargs...)
 
 function gmres!(x, A, b;
-    tol=sqrt(eps(typeof(real(b[1])))), restart::Int=min(20,length(b)),
-    maxiter::Int=restart, plot::Bool=false, log::Bool=false, kwargs...
+    tol = sqrt(eps(typeof(real(b[1])))), restart::Int=min(20,length(b)),
+    maxiter::Int = restart, plot::Bool=false, log::Bool=false, kwargs...
     )
     (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial=!log, restart=restart)
@@ -26,7 +26,7 @@ end
 
 #One Arnoldi iteration
 #Optionally takes a truncation parameter l
-function arnoldi!(K::KrylovSubspace, w; l=K.order)
+function arnoldi(K::KrylovSubspace, w; l=K.order)
     v = nextvec(K)
     w = copy(v)
     n = min(length(K.v), l)
@@ -86,7 +86,7 @@ function gmres_method!(log::ConvergenceHistory, x, A, b;
         for j = 1:restart
             nextiter!(log, mvps=1)
             #Calculate next orthonormal basis vector in the Krylov subspace
-            H[1:j+1, j] = arnoldi!(K, w)
+            H[1:j+1, j] = arnoldi(K, w)
 
             #Update QR factorization of H
             #The Q is stored as a series of Givens rotations in J


### PR DESCRIPTION
cg.jl had several memory leaks arising from https://github.com/JuliaMath/IterativeSolvers.jl/blob/master/src/cg.jl#L45
and 
https://github.com/JuliaMath/IterativeSolvers.jl/blob/master/src/cg.jl#L54.
``` julia
julia> @time x = cg(A, rhs; maxiter=2000);
  0.073056 seconds (12.04 k allocations: 31.635 MB, 14.14% gc time)
```
In this PR I have defined mutating functions for these functionalities and now we have
``` julia
julia> @time cg(A, rhs; maxiter=2000);
  0.051681 seconds (8.04 k allocations: 714.328 KB)
```

Please note that I have found many such areas of optimizations in gmres.jl, lancoz.jl etc. but due to want of time I won't be able to address those issues. 
Maybe @haampie can fix these during the summer.