### PR TITLE
Reduce memory usage in CG

### DIFF
--- a/benchmark/benchmark-linear-systems.jl
+++ b/benchmark/benchmark-linear-systems.jl
@@ -1,0 +1,44 @@
+module LinearSystemsBench
+
+import Base.A_ldiv_B!, Base.\
+
+using BenchmarkTools
+using IterativeSolvers
+
+# A DiagonalMatrix that doesn't check whether it is singular in the \ op.
+immutable DiagonalPreconditioner{T}
+    diag::Vector{T}
+end
+
+function A_ldiv_B!{T}(y::AbstractVector{T}, A::DiagonalPreconditioner{T}, b::AbstractVector{T})
+    for i = 1 : length(b)
+        @inbounds y[i] = A.diag[i] \ b[i]
+    end
+    y
+end
+
+(\)(D::DiagonalPreconditioner, b::AbstractVector) = D.diag .\ b
+
+function posdef(n)
+    A = SymTridiagonal(fill(2.01, n), fill(-1.0, n))
+    b = A * ones(n)
+    return A, b
+end
+
+function cg(; n = 1_000_000, tol = 1e-6, maxiter::Int = 200)
+    A, b = posdef(n)
+    P = DiagonalPreconditioner(collect(linspace(1.0, 2.0, n)))
+
+    println("Symmetric positive definite matrix of size ", n)
+    println("Eigenvalues in interval [0.01, 4.01]")
+    println("Tolerance = ", tol, "; max #iterations = ", maxiter)
+    
+    # Dry run
+    initial = rand(n)
+    IterativeSolvers.cg!(copy(initial), A, b, Pl = P, maxiter = maxiter, tol = tol, log = false)
+
+    # Actual benchmark
+    @benchmark IterativeSolvers.cg!(x0, $A, $b, Pl = $P, maxiter = $maxiter, tol = $tol, log = false) setup=(x0 = copy($initial))
+end
+
+end

--- a/test/getDivGrad.jl
+++ b/test/getDivGrad.jl
@@ -33,5 +33,5 @@ function spdiags(B,d,m,n)
         a[(round(Int, len[k])+1):round(Int, len[k+1]),:] = [i i+d[k] B[i+(m >= n)*d[k], k]]
     end
 
-    sparse(round(Int, a[:,1]), round(Int, a[:,2]), a[:,3], m, n)
+    sparse(round.(Int, a[:,1]), round.(Int, a[:,2]), a[:,3], m, n)
 end


### PR DESCRIPTION
- Pre-allocates the vectors, improvement shown below.
- Removes the dependency of CG on KrylovSubspace (makes little sense for a 3-term recurrence method IMHO). Also: the KrylovSubspace methods are the main reason for inefficient memory usage. For the moment it was easier to fix just CG.
- Fixes a bug where the CG method starts while the initial guess is the actual solution (I still have to add a test for this)
- Adds a simple benchmark for the CG method
- Relies always on `A_mul_B!` for matrix-vector products. Since we're switching to LinearMaps this shouldn't be a problem.
- Also: removes the check whether all elements of `b` are zero. I would say CG should not be responsible for this.

Benchmark results:

```
LinearSystemsBench.cg()
```

*This PR*
```
BenchmarkTools.Trial:
  memory estimate:  45.80 MiB
  allocs estimate:  437
  --------------
  minimum time:     2.561 s (0.16% GC)
  median time:      2.580 s (0.27% GC)
  mean time:        2.580 s (0.27% GC)
  maximum time:     2.598 s (0.38% GC)
  --------------
  samples:          2
  evals/sample:     1
```

*Current implementation*
```
  BenchmarkTools.Trial:
  memory estimate:  1.53 GiB
  allocs estimate:  1041
  --------------
  minimum time:     3.173 s (9.28% GC)
  median time:      3.246 s (11.98% GC)
  mean time:        3.246 s (11.98% GC)
  maximum time:     3.320 s (14.57% GC)
  --------------
  samples:          2
  evals/sample:     1
```

