### PR TITLE
Fix CG without preconditioning

### DIFF
--- a/src/cg.jl
+++ b/src/cg.jl
@@ -7,60 +7,76 @@ function cg!(x, A, b;
     maxiter::Integer = min(20, size(A, 1)),
     plot = false,
     log::Bool = false,
+    Pl = Identity(),
     kwargs...
 )
     (plot & !log) && error("Can't plot when log keyword is false")
-    K = KrylovSubspace(A, length(b), 1, Vector{Adivtype(A,b)}[])
-    init!(K, x)
     history = ConvergenceHistory(partial = !log)
     history[:tol] = tol
-    reserve!(history, :resnorm, maxiter)
-    cg_method!(history, x, K, b; tol = tol, maxiter = maxiter, kwargs...)
-    (plot || log) && shrink!(history)
+    log && reserve!(history, :resnorm, maxiter + 1)
+    cg_method!(history, x, A, b, Pl; tol = tol, log = log, maxiter = maxiter, kwargs...)
+    log && shrink!(history)
     plot && showplot(history)
     log ? (x, history) : x
 end
 
-function cg_method!(log::ConvergenceHistory, x, K, b;
-    Pl = 1,
+function cg_method!(history::ConvergenceHistory, x, A, b, Pl;
     tol = sqrt(eps(real(eltype(b)))),
-    maxiter::Integer = min(20, size(K.A, 1)),
-    verbose::Bool = false
+    maxiter::Integer = min(20, size(A, 1)),
+    verbose::Bool = false,
+    log = false
 )
+    # Preconditioned CG
     T = eltype(b)
-    n = size(K.A, 1)
+    n = size(A, 1)
 
     # Initial residual vector
     r = copy(b)
-    @blas! r -= one(T) * nextvec(K)
-    c = zeros(T, n)
+    c = A * x
+    @blas! r -= one(T) * c
     u = zeros(T, n)
     ρ = one(T)
-    
-    iter = 0
 
-    last_residual = norm(r)
+    if log
+        history.mvps += 1
+    end
+    
+    iter = 1
 
     # Here you could save one inner product if norm(r) is used rather than norm(b)
     reltol = norm(b) * tol
+    last_residual = zero(T)
 
-    while last_residual > reltol && iter < maxiter
-        nextiter!(log, mvps = 1)
+    while true
+
+        last_residual = norm(r)
+
+        verbose && @printf("%3d\t%1.2e\n", iter, last_residual)
+
+        if last_residual ≤ reltol || iter > maxiter
+            break
+        end
+
+        # Log progress        
+        if log
+            nextiter!(history, mvps = 1)
+            push!(history, :resnorm, last_residual)
+        end
 
         # Preconditioner: c = Pl \ r
         solve!(c, Pl, r)
 
         ρ_prev = ρ
         ρ = dot(c, r)
-        β = -ρ / ρ_prev
+        β = ρ / ρ_prev
 
-        # u := r - βu (almost an axpy)
-        @blas! u *= -β
-        @blas! u += one(T) * c
+        # u := c + βu (almost an axpy)
+        @inbounds @simd for i = 1 : length(u)
+           u[i] = c[i] + β * u[i]
+        end
 
         # c = A * u
-        append!(K, u)
-        nextvec!(c, K)
+        A_mul_B!(c, A, u)
         α = ρ / dot(u, c)
     
         # Improve solution and residual
@@ -68,18 +84,83 @@ function cg_method!(log::ConvergenceHistory, x, K, b;
         @blas! r -= α * c
 
         iter += 1
-        last_residual = norm(r)
-
-        # Log progress
-        push!(log, :resnorm, last_residual)
-        verbose && @printf("%3d\t%1.2e\n", iter, last_residual)
     end
 
     verbose && @printf("\n")
-    setconv(log, last_residual < reltol)
+    log && setconv(history, last_residual < reltol)
 
     x
 end
+
+function cg_method!(history::ConvergenceHistory, x, A, b, Pl::Identity;
+    tol = sqrt(eps(real(eltype(b)))),
+    maxiter::Integer = min(20, size(A, 1)),
+    verbose::Bool = false,
+    log = false
+)
+    # Unpreconditioned CG
+    T = eltype(b)
+    n = size(A, 1)
+
+    # Initial residual vector
+    r = copy(b)
+    c = A * x
+    @blas! r -= one(T) * c
+    u = zeros(T, n)
+    ρ = one(T)
+
+    if log
+        history.mvps += 1
+    end
+
+    iter = 1
+
+    reltol = norm(b) * tol
+    last_residual = zero(T)
+
+    while true
+
+        ρ_prev = ρ
+        ρ = dot(r, r)
+        β = ρ / ρ_prev
+
+        last_residual = sqrt(ρ)
+
+        # Log progress
+        if log
+            nextiter!(history, mvps = 1)
+            push!(history, :resnorm, last_residual)
+        end
+
+        verbose && @printf("%3d\t%1.2e\n", iter, last_residual)
+
+        # Stopping condition
+        if last_residual ≤ reltol || iter > maxiter
+            break
+        end
+
+        # u := r + βu (almost an axpy)
+        @inbounds @simd for i = 1 : length(u)
+           u[i] = r[i] + β * u[i]
+        end
+
+        # c = A * u
+        A_mul_B!(c, A, u)
+        α = ρ / dot(u, c)
+    
+        # Improve solution and residual
+        @blas! x += α * u
+        @blas! r -= α * c
+
+        iter += 1
+    end
+
+    verbose && @printf("\n")
+    log && setconv(history, last_residual < reltol)
+
+    x
+end
+
 
 #################
 # Documentation #
@@ -126,7 +207,7 @@ $arg
 
 ## Keywords
 
-`Pl = 1`: left preconditioner of the method.
+`Pl = Identity()`: left preconditioner of the method.
 
 `tol::Real = size(A,2)*eps()`: stopping tolerance.
 

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -71,9 +71,8 @@ function cg_method!(history::ConvergenceHistory, x, A, b, Pl;
         β = ρ / ρ_prev
 
         # u := c + βu (almost an axpy)
-        @inbounds @simd for i = 1 : length(u)
-           u[i] = c[i] + β * u[i]
-        end
+        @blas! u *= β
+        @blas! u += one(T) * c
 
         # c = A * u
         A_mul_B!(c, A, u)
@@ -140,9 +139,8 @@ function cg_method!(history::ConvergenceHistory, x, A, b, Pl::Identity;
         end
 
         # u := r + βu (almost an axpy)
-        @inbounds @simd for i = 1 : length(u)
-           u[i] = r[i] + β * u[i]
-        end
+        @blas! u *= β
+        @blas! u += one(T) * r
 
         # c = A * u
         A_mul_B!(c, A, u)

--- a/src/common.jl
+++ b/src/common.jl
@@ -3,7 +3,7 @@ import  Base: eltype, length, ndims, real, size, *,
 
 using   LinearMaps
 
-export  A_mul_B
+export  A_mul_B, Identity
 
 #### Type-handling
 """

--- a/src/common.jl
+++ b/src/common.jl
@@ -74,3 +74,10 @@ type PosSemidefException <: Exception
     msg :: AbstractString
     PosSemidefException(msg::AbstractString="Matrix was not positive semidefinite") = new(msg)
 end
+
+# Identity preconditioner
+immutable Identity end
+
+Base.:\(::Identity, x) = copy(x)
+Base.A_ldiv_B!(::Identity, x) = x
+Base.A_ldiv_B!(y, ::Identity, x) = copy!(y, x)

--- a/test/common.jl
+++ b/test/common.jl
@@ -12,6 +12,17 @@ context("Adivtype") do
     @fact IterativeSolvers.Adivtype(A, b) --> Float32
 end
 
+context("Identity preconditioner") do
+    P = Identity()
+    x = rand(10)
+    y = zeros(x)
+
+    # Should be a no-op
+    @fact P \ x --> x
+    @fact A_ldiv_B!(P, copy(x)) --> x
+    @fact A_ldiv_B!(y, P, copy(x)) --> x
+end
+
 context("Linear operator defined as a function") do
     # A = cycle-back operator
     function shiftback!(output, b)


### PR DESCRIPTION
This PR makes CG without preconditioning ~30% more efficient in wall-clock time. Optimizations in the non-preconditioned case are:

1. The residual `norm(r)` is implicitly available, so it doesn't have to be computed.
2. `dot(r, c)` becomes `dot(r, r)`; since this operation is memory-bound, it's twice as fast.
3. No need to copy the `r` vector to `c` when "preconditioning".
