### PR TITLE
BiCGStab(ℓ)

### DIFF
--- a/benchmark/benchmark-linear-systems.jl
+++ b/benchmark/benchmark-linear-systems.jl
@@ -5,6 +5,8 @@ import Base.A_ldiv_B!, Base.\
 using BenchmarkTools
 using IterativeSolvers
 
+include("../test/advection_diffusion.jl")
+
 # A DiagonalMatrix that doesn't check whether it is singular in the \ op.
 immutable DiagonalPreconditioner{T}
     diag::Vector{T}
@@ -62,6 +64,17 @@ function gmres(; n = 100_000, tol = 1e-5, restart::Int = 15, maxiter::Int = 210)
     old = @benchmark IterativeSolvers.gmres($A, $b, tol = $tol, restart = $restart, maxiter = $maxiter, log = false)
 
     impr, old
+end
+
+function bicgstabl()
+    A, b = advection_dominated()
+
+    b1 = @benchmark IterativeSolvers.bicgstabl($A, $b, 2, max_mv_products = 1000, convex_combination = false) setup = (srand(1))
+    b2 = @benchmark IterativeSolvers.bicgstabl($A, $b, 2, max_mv_products = 1000, convex_combination = true) setup = (srand(1))
+    b3 = @benchmark IterativeSolvers.bicgstabl($A, $b, 4, max_mv_products = 1000, convex_combination = false) setup = (srand(1))
+    b4 = @benchmark IterativeSolvers.bicgstabl($A, $b, 4, max_mv_products = 1000, convex_combination = true) setup = (srand(1))
+
+    b1, b2, b3, b4
 end
 
 end

--- a/src/IterativeSolvers.jl
+++ b/src/IterativeSolvers.jl
@@ -21,6 +21,7 @@ include("hessenberg.jl")
 #Linear solvers
 include("stationary.jl")
 include("cg.jl")
+include("bicgstabl.jl")
 include("gmres.jl")
 include("chebyshev.jl")
 include("idrs.jl")

--- a/src/bicgstabl.jl
+++ b/src/bicgstabl.jl
@@ -1,0 +1,188 @@
+export bicgstabl, bicgstabl!
+
+bicgstabl(A, b, l::Int = 2; kwargs...) = bicgstabl!(zeros(b), A, b, l; initial_zero = true, kwargs...)
+
+function bicgstabl!(x, A, b, l::Int = 2;
+    Pl = Identity(),
+    max_mv_products = min(30, size(A, 1)),
+    initial_zero = false,
+    tol = sqrt(eps(real(eltype(b)))),
+    visitor = (a...) -> nothing
+)
+    T = eltype(b)
+    n = size(A, 1)
+
+    mv_products = 0
+    residuals = real(T)[]
+
+    rs = zeros(T, n, l + 1)
+    us = zeros(T, n, l + 1)
+
+    # Views of the first columns for ease of reference
+    u = view(us, :, 1)
+    residual = view(rs, :, 1)
+    
+    # Compute the initial residual rs[:, 1] = b - A * x
+    # Avoid computing A * 0.
+    if initial_zero
+        copy!(residual, b)
+    else
+        A_mul_B!(residual, A, x)
+        @blas! residual -= one(T) * b
+        @blas! residual *= -one(T)
+        mv_products += 1
+    end
+
+    # Apply the left preconditioner
+    A_ldiv_B!(Pl, residual)
+
+    # Random shadow residual
+    r_shadow = rand(T, n)
+
+    γ = zeros(T, l)
+    γ[l] = σ = one(T)
+
+    nrm = norm(residual)
+    push!(residuals, nrm)
+    iter = 1
+
+    # For the least-squares problem
+    M = zeros(T, l + 1, l + 1)
+    L = 2 : l + 1
+
+    # Stopping condition based on relative tolerance.
+    reltol = nrm * tol
+
+    while nrm > reltol && mv_products < max_mv_products
+        σ = -γ[l] * σ
+        
+        # BiCG part
+        for j = 1 : l
+            ρ = dot(r_shadow, view(rs, :, j))
+            β = ρ / σ
+            
+            # us[:, 1 : j] .= rs[:, 1 : j] - β * us[:, 1 : j]
+            for i = 1 : j
+                @blas! view(us, :, i) *= -β
+                @blas! view(us, :, i) += one(T) * view(rs, :, i)
+            end
+
+            # us[:, j + 1] = Pl \ (A * us[:, j])            
+            A_mul_B!(view(us, :, j + 1), A , view(us, :, j))
+            A_ldiv_B!(Pl, view(us, :, j + 1))
+            mv_products += 1
+
+            σ = dot(r_shadow, view(us, :, j + 1))
+            α = ρ / σ
+
+            # rs[:, 1 : j] .= rs[:, 1 : j] - α * us[:, 2 : j + 1]
+            for i = 1 : j
+                @blas! view(rs, :, i) -= α * view(us, :, i + 1)
+            end
+            
+            # rs[:, j + 1] = Pl \ (A * rs[:, j])
+            A_mul_B!(view(rs, :, j + 1), A , view(rs, :, j))
+            A_ldiv_B!(Pl, view(rs, :, j + 1))
+            mv_products += 1
+            
+            # x = x + α * us[:, 1]
+            @blas! x += α * u
+        end
+
+        # MR part: M = rs' * rs
+        Ac_mul_B!(M, rs, rs)
+        
+        # γ = M[L, L] \ M[L, 1] 
+        F = lufact!(view(M, L, L))
+        A_ldiv_B!(γ, F, view(M, L, 1))
+
+        # This could even be BLAS 3 when combined.
+        BLAS.gemv!('N', -one(T), view(us, :, L), γ, one(T), u)
+        BLAS.gemv!('N', one(T), view(rs, :, 1 : l), γ, one(T), x)
+        BLAS.gemv!('N', -one(T), view(rs, :, L), γ, one(T), residual)
+        
+        nrm = norm(residual)
+        
+        visitor(nrm, mv_products)
+    end
+
+    x, nrm
+end
+
+#################
+# Documentation #
+#################
+
+let
+doc_call = "bicgstab(A, b, l)"
+doc!_call = "bicgstab!(x, A, b, l)"
+
+doc_msg = "Solve A*x = b with the BiCGStab(l)"
+doc!_msg = "Overwrite `x`.\n\n" * doc_msg
+
+doc_arg = ""
+doc!_arg = """`x`: initial guess, overwrite final estimation."""
+
+doc_version = (doc_call, doc_msg, doc_arg)
+doc!_version = (doc!_call, doc!_msg, doc!_arg)
+
+docstring = String[]
+
+#Build docs
+for (call, msg, arg) in (doc_version, doc!_version) #Start
+    push!(docstring, 
+"""
+$call
+
+$msg
+
+# Arguments
+
+$arg
+
+`A`: linear operator.
+
+`b`: right hand side (vector).
+
+`l::Int = 2`: Number of GMRES steps.
+
+## Keywords
+
+`Pl = Identity()`: left preconditioner of the method.
+
+`tol::Real = sqrt(eps(real(eltype(b))))`: tolerance for stopping condition 
+`|r_k| / |r_0| ≤ tol`. Note that:
+
+1. The actual residual is never computed during the iterations; only an 
+approximate residual is used.
+2. If a preconditioner is given, the stopping condition is based on the 
+*preconditioned residual*.
+
+`max_mv_products::Int = min(30, size(A, 1))`: maximum number of matrix
+vector products. For BiCGStab this is a less dubious criterion than maximum
+number of iterations.
+
+`visitor`: a callback that get's called after each outer iteration, with arguments
+`visitor(nrm, mv_products)`. For example use
+
+```julia
+logger(nrm, mv_products) = println(mv_products, " ", nrm)
+x, residual = bicgstab(A, b, visitor = logger)
+```
+
+# Output
+
+`x`: approximated solution.
+`residual`: last approximate residual norm
+
+# References
+[1] Sleijpen, Gerard LG, and Diederik R. Fokkema. "BiCGstab(l) for 
+linear equations involving unsymmetric matrices with complex spectrum." 
+Electronic Transactions on Numerical Analysis 1.11 (1993): 2000.
+"""
+    )
+end
+
+@doc docstring[1] -> bicgstabl
+@doc docstring[2] -> bicgstabl!
+end

--- a/src/bicgstabl.jl
+++ b/src/bicgstabl.jl
@@ -114,11 +114,11 @@ function bicgstabl!(x, A, b, l::Int = 2;
             κ0 = √(y0' * M * y0)
             κl = √(yl' * M * yl)
             ϱ = yl' * M * y0 / (κ0 * κl)
-            γ̂ = ϱ / abs(ϱ) * max(abs(ϱ), 0.7)
+            γ̂ = ϱ / abs(ϱ) * max(abs(ϱ), real(T)(0.7))
             y0 -= γ̂ * (κ0 / κl) * yl
-            ω = y0[l + 1]
 
-            nrm = √(y0' * M * y0)
+            ω = y0[l + 1]
+            nrm = √abs(y0' * M * y0)
 
             # This could even be BLAS 3 when combined.
             # Also: views don't change during the iterations.
@@ -135,6 +135,7 @@ function bicgstabl!(x, A, b, l::Int = 2;
             BLAS.gemv!('N', one(T), view(rs, :, 1 : l), γ, one(T), x)
             BLAS.gemv!('N', -one(T), view(rs, :, L), γ, one(T), residual)
 
+            ω = γ[l]
             nrm = norm(residual)
         end
         

--- a/src/bicgstabl.jl
+++ b/src/bicgstabl.jl
@@ -13,7 +13,6 @@ function bicgstabl!(x, A, b, l::Int = 2;
     n = size(A, 1)
 
     mv_products = 0
-    residuals = real(T)[]
 
     rs = zeros(T, n, l + 1)
     us = zeros(T, n, l + 1)
@@ -43,7 +42,6 @@ function bicgstabl!(x, A, b, l::Int = 2;
     γ[l] = σ = one(T)
 
     nrm = norm(residual)
-    push!(residuals, nrm)
     iter = 1
 
     # For the least-squares problem

--- a/src/bicgstabl.jl
+++ b/src/bicgstabl.jl
@@ -14,6 +14,7 @@ function bicgstabl!(x, A, b, l::Int = 2;
 
     mv_products = 0
 
+    # Large vectors.
     rs = zeros(T, n, l + 1)
     us = zeros(T, n, l + 1)
 
@@ -89,6 +90,9 @@ function bicgstabl!(x, A, b, l::Int = 2;
 
         # MR part: M = rs' * rs
         Ac_mul_B!(M, rs, rs)
+        
+        # For l = 2 this would be an LU decomp of a 2 x 2 matrix
+        # Maybe a bit overkill
         
         # γ = M[L, L] \ M[L, 1] 
         F = lufact!(view(M, L, L))

--- a/test/advection_diffusion.jl
+++ b/test/advection_diffusion.jl
@@ -1,0 +1,46 @@
+f(x, y, z) = exp.(x .* y .* z) .* sin.(π .* x) .* sin.(π .* y) .* sin.(π .* z)
+
+function advection_dominated(;N = 50, β = 1000.0)
+    # Problem: Δu + βuₓ = f
+    # u = 0 on the boundaries
+    # f(x, y, z) = exp(xyz) sin(πx) sin(πy) sin(πz)
+    # 2nd order central differences (shows serious wiggles)
+
+    # Total number of unknowns
+    n = N^3
+
+    # Mesh width
+    h = 1.0 / (N + 1)
+
+    # Interior points only
+    xs = linspace(0, 1, N + 2)[2 : N + 1]
+
+    # The Laplacian
+    Δ = laplace_matrix(Float64, N, 3) ./ -h^2
+
+    # And the dx bit.
+    ∂x_1d = spdiagm((fill(-β / 2h, N - 1), fill(β / 2h, N - 1)), (-1, 1))
+    ∂x = kron(speye(N^2), ∂x_1d)
+
+    # Final matrix and rhs.
+    A = Δ + ∂x
+    b = reshape([f(x, y, z) for x ∈ xs, y ∈ xs, z ∈ xs], n)
+
+    A, b
+end
+
+function laplace_matrix{T}(::Type{T}, n, dims)
+    D = second_order_central_diff(T, n)
+    A = copy(D)
+
+    for idx = 2 : dims
+        A = kron(A, speye(n)) + kron(speye(size(A, 1)), D)
+    end
+
+    A
+end
+
+second_order_central_diff{T}(::Type{T}, dim) = convert(
+    SparseMatrixCSC{T, Int}, 
+    SymTridiagonal(fill(2 * one(T), dim), fill(-one(T), dim - 1))
+)

--- a/test/bicgstabl.jl
+++ b/test/bicgstabl.jl
@@ -17,18 +17,16 @@ for T in (Float32, Float64, Complex64, Complex128)
         b = A * x
 
         for l = (2, 4)
-            for convex_combination = (false, true)
-                context("BiCGStab($l) convex = $convex_combination") do
+            context("BiCGStab($l)") do
 
-                # Solve without preconditioner
-                x1, res1 = bicgstabl(A, b, l, max_mv_products = 100, convex_combination = convex_combination)
-                @fact norm(A * x1 - b) / norm(b) --> less_than(√eps(real(one(T))))
+            # Solve without preconditioner
+            x1, his1 = bicgstabl(A, b, l, max_mv_products = 100, log = true)
+            @fact norm(A * x1 - b) / norm(b) --> less_than(√eps(real(one(T))))
 
-                # Do an exact LU decomp of a nearby matrix
-                F = lufact(A + rand(T, n, n))
-                x2, res2 = bicgstabl(A, b, Pl = F, l, max_mv_products = 100, convex_combination = convex_combination)
-                @fact norm(A * x2 - b) / norm(b) --> less_than(√eps(real(one(T))))
-                end
+            # Do an exact LU decomp of a nearby matrix
+            F = lufact(A + rand(T, n, n))
+            x2, his2 = bicgstabl(A, b, Pl = F, l, max_mv_products = 100, log = true)
+            @fact norm(A * x2 - b) / norm(b) --> less_than(√eps(real(one(T))))
             end
         end
     end

--- a/test/bicgstabl.jl
+++ b/test/bicgstabl.jl
@@ -11,19 +11,26 @@ facts("bicgstab(l)") do
 for T in (Float32, Float64, Complex64, Complex128)
     context("Matrix{$T}") do
 
-        n = 15
+        n = 20
         A = rand(T, n, n) + 15 * eye(T, n)
         x = ones(T, n)
         b = A * x
 
-        # Solve without preconditioner
-        x1, res1 = bicgstabl(A, b)
-        @fact norm(A * x1 - b) / norm(b) --> less_than(√eps(real(one(T))))
+        for l = (2, 4)
+            for convex_combination = (false, true)
+                context("BiCGStab($l) convex = $convex_combination") do
 
-        # Do an exact LU decomp of a nearby matrix
-        F = lufact(A + rand(T, n, n))
-        x2, res2 = bicgstabl(A, b, Pl = F)
-        @fact norm(A * x2 - b) / norm(b) --> less_than(√eps(real(one(T))))
+                # Solve without preconditioner
+                x1, res1 = bicgstabl(A, b, l, max_mv_products = 100, convex_combination = convex_combination)
+                @fact norm(A * x1 - b) / norm(b) --> less_than(√eps(real(one(T))))
+
+                # Do an exact LU decomp of a nearby matrix
+                F = lufact(A + rand(T, n, n))
+                x2, res2 = bicgstabl(A, b, Pl = F, l, max_mv_products = 100, convex_combination = convex_combination)
+                @fact norm(A * x2 - b) / norm(b) --> less_than(√eps(real(one(T))))
+                end
+            end
+        end
     end
 end
 end

--- a/test/bicgstabl.jl
+++ b/test/bicgstabl.jl
@@ -1,0 +1,29 @@
+using IterativeSolvers
+using FactCheck
+using LinearMaps
+
+srand(1234321)
+
+include("advection_diffusion.jl")
+
+facts("bicgstab(l)") do
+
+for T in (Float32, Float64, Complex64, Complex128)
+    context("Matrix{$T}") do
+
+        n = 15
+        A = rand(T, n, n) + 15 * eye(T, n)
+        x = ones(T, n)
+        b = A * x
+
+        # Solve without preconditioner
+        x1, res1 = bicgstabl(A, b)
+        @fact norm(A * x1 - b) / norm(b) --> less_than(√eps(real(one(T))))
+
+        # Do an exact LU decomp of a nearby matrix
+        F = lufact(A + rand(T, n, n))
+        x2, res2 = bicgstabl(A, b, Pl = F)
+        @fact norm(A * x2 - b) / norm(b) --> less_than(√eps(real(one(T))))
+    end
+end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,9 @@ include("stationary.jl")
 #Conjugate gradients
 include("cg.jl")
 
+#BiCGStab(l)
+include("bicgstabl.jl")
+
 #GMRES
 include("gmres.jl")
 


### PR DESCRIPTION
This is still a work in progress version of BiCGStab(ℓ). It is based on the original article, uses BLAS and includes left preconditioning.

Todo:

- [x] Incorporate the convergence history stuff.
- [x] ~Improvement of [1]~
- [x] ~Improvement of [2]~

[1] Sleijpen, Gerard LG, and Henk A. Vorst. "Maintaining convergence properties of BiCGstab methods in finite precision arithmetic." Numerical Algorithms 10.2 (1995): 203-223.
[2] Sleijpen, G. LG, and Henk A. van der Vorst. "Reliable updated residuals in hybrid Bi-CG methods." Computing 56.2 (1996): 141-163.