### PR TITLE
Remove plotting from algorithms

### DIFF
--- a/docs/src/user_manual.md
+++ b/docs/src/user_manual.md
@@ -79,8 +79,6 @@ etc.
 `log::Bool = false`: output an extra element of type `ConvergenceHistory`
 containing extra information of the method execution.
 
-`plot`: plot information relevant to the method. (Only for `Master` version)
-
 ### `log` keyword
 
 All solvers contain the `log` keyword. This is to be used when obtaining
@@ -88,12 +86,10 @@ more information is required, to use it place the set `log` to `true`.
 
 ```julia
 x, ch = cg(Master, rand(10, 10), rand(10) log=true)
-svd, L, ch = svdl(Master, rand(100, 100), plot=true, log=true)
+svd, L, ch = svdl(Master, rand(100, 100), log=true)
 ```
 
 The function will now return one more parameter of type `ConvergenceHistory`.
-
-*`Note:`*  Keyword argument `plot` is only available when `log` is set.
 
 ## ConvergenceHistory
 

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -5,18 +5,15 @@ cg(A, b; kwargs...) = cg!(zerox(A, b), A, b; kwargs...)
 function cg!(x, A, b;
     tol = sqrt(eps(real(eltype(b)))),
     maxiter::Integer = min(20, size(A, 1)),
-    plot = false,
     log::Bool = false,
     Pl = Identity(),
     kwargs...
 )
-    (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial = !log)
     history[:tol] = tol
     log && reserve!(history, :resnorm, maxiter + 1)
     cg_method!(history, x, A, b, Pl; tol = tol, log = log, maxiter = maxiter, kwargs...)
     log && shrink!(history)
-    plot && showplot(history)
     log ? (x, history) : x
 end
 
@@ -193,7 +190,6 @@ $msg
 
 If `log` is set to `true` is given, method will output a tuple `x, ch`. Where
 `ch` is a `ConvergenceHistory` object. Otherwise it will only return `x`.
-The `plot` attribute can only be used when `log` is set version.
 
 # Arguments
 
@@ -215,8 +211,6 @@ $arg
 
 `log::Bool = false`: output an extra element of type `ConvergenceHistory`
 containing extra information of the method execution.
-
-`plot::Bool = false`: plot data. (Only when `log` is set)
 
 # Output
 

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -9,18 +9,15 @@ chebyshev(A, b, λmin::Real, λmax::Real; kwargs...) =
 
 function chebyshev!(x, A, b, λmin::Real, λmax::Real;
     n::Int=size(A,2), tol::Real = sqrt(eps(typeof(real(b[1])))),
-    maxiter::Int = n^3, plot::Bool=false, log::Bool=false, kwargs...
+    maxiter::Int = n^3, log::Bool=false, kwargs...
     )
 	K = KrylovSubspace(A, n, 1, Adivtype(A, b))
 	init!(K, x)
-
-    (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(history,:resnorm,maxiter)
     chebyshev_method!(history, x, K, b, λmin, λmax; tol=tol, maxiter=maxiter, kwargs...)
-    (plot || log) && shrink!(history)
-    plot && showplot(history)
+    log && shrink!(history)
     log ? (x, history) : x
 end
 
@@ -101,8 +98,6 @@ $msg
 If `log` is set to `true` is given, method will output a tuple `x, ch`. Where
 `ch` is a `ConvergenceHistory` object. Otherwise it will only return `x`.
 
-The `plot` attribute can only be used when `log` is set version.
-
 # Arguments
 
 $arg
@@ -123,8 +118,6 @@ $arg
 
 `log::Bool = false`: output an extra element of type `ConvergenceHistory`
 containing extra information of the method execution.
-
-`plot::Bool = false`: plot data. (Only with `Master` version)
 
 # Output
 

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -8,17 +8,14 @@ function gmres!(x, A, b;
   tol = sqrt(eps(real(eltype(b)))),
   restart::Int = min(20, length(b)),
   maxiter::Int = restart,
-  plot::Bool = false,
   log::Bool = false,
   kwargs...
 )
-    (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial = !log, restart = restart)
     history[:tol] = tol
     log && reserve!(history, :resnorm, maxiter)
     gmres_method!(history, x, A, b; Pl = Pl, Pr = Pr, tol = tol, maxiter = maxiter, restart = restart, log = log, kwargs...)
-    (plot || log) && shrink!(history)
-    plot && showplot(history)
+    log && shrink!(history)
     log ? (x, history) : x
 end
 

--- a/src/history.jl
+++ b/src/history.jl
@@ -265,7 +265,6 @@ plotable(::Any)::Bool = false
     showplot(ch)
 
 Print all plotable information inside `ConvergenceHistory` `ch`.
-*Note:* This is what is called when the `plot` keyword is set.
 """
 function showplot(ch::ConvergenceHistory)
     candidates = collect(values(ch.data))

--- a/src/idrs.jl
+++ b/src/idrs.jl
@@ -9,15 +9,13 @@ idrs(A, b; kwargs...) = idrs!(zerox(A,b), A, b; kwargs...)
 
 function idrs!(x, A, b;
     s = 8, tol=sqrt(eps(typeof(real(b[1])))), maxiter=length(x)^2,
-    plot::Bool=false, log::Bool=false, kwargs...
+    log::Bool=false, kwargs...
     )
-    (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     idrs_method!(history, x, linsys_op, (A,), b, s, tol, maxiter; kwargs...)
-    (plot || log) && shrink!(history)
-    plot && showplot(history)
+    log && shrink!(history)
     log ? (x, history) : x
 end
 
@@ -228,8 +226,6 @@ $msg
 If `log` is set to `true` is given, method will output a tuple `x, ch`. Where
 `ch` is a `ConvergenceHistory` object. Otherwise it will only return `x`.
 
-The `plot` attribute can only be used when `log` is set version.
-
 # Arguments
 
 $arg
@@ -254,8 +250,6 @@ $arg
 
 `log::Bool = false`: output an extra element of type `ConvergenceHistory`
 containing extra information of the method execution.
-
-`plot::Bool = false`: plot data. (Only when `log` is set)
 
 # Output
 

--- a/src/lanczos.jl
+++ b/src/lanczos.jl
@@ -7,16 +7,14 @@ export eiglancz
 ####################
 
 function eiglancz(A;
-    maxiter::Integer=size(A,1), plot::Bool=false,
+    maxiter::Integer=size(A,1),
     tol::Real = size(A,1)^3*eps(real(eltype(A))), log::Bool=false, kwargs...
     )
-    (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     e1 = eiglancz_method(history, A; maxiter=maxiter, tol=tol, kwargs...)
-    (plot || log) && shrink!(history)
-    plot && showplot(history)
+    log && shrink!(history)
     log ? (e1, history) : e1
 end
 
@@ -89,8 +87,6 @@ $msg
 If `log` is set to `true` is given, method will output a tuple `eigs, ch`. Where
 `ch` is a `ConvergenceHistory` object. Otherwise it will only return `eigs`.
 
-The `plot` attribute can only be used when `log` is set version.
-
 # Arguments
 
 $arg
@@ -109,8 +105,6 @@ $arg
 
 `log::Bool = false`: output an extra element of type `ConvergenceHistory`
 containing extra information of the method execution.
-
-`plot::Bool = false`: plot data. (Only when `log` is set)
 
 # Output
 

--- a/src/lsmr.jl
+++ b/src/lsmr.jl
@@ -9,10 +9,9 @@ using Base.LinAlg
 lsmr(A, b; kwargs...) = lsmr!(zerox(A, b), A, b; kwargs...)
 
 function lsmr!(x, A, b;
-    plot::Bool=false, maxiter::Integer = max(size(A,1), size(A,2)),
+    maxiter::Integer = max(size(A,1), size(A,2)),
     log::Bool=false, kwargs...
     )
-    (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial=!log)
     reserve!(history,[:anorm,:rnorm,:cnorm],maxiter)
 
@@ -22,8 +21,7 @@ function lsmr!(x, A, b;
     copy!(btmp, b)
     v, h, hbar = similar(x, T), similar(x, T), similar(x, T)
     lsmr_method!(history, x, A, btmp, v, h, hbar; maxiter=maxiter, kwargs...)
-    (plot || log) && shrink!(history)
-    plot && showplot(history)
+    log && shrink!(history)
     log ? (x, history) : x
 end
 
@@ -273,8 +271,6 @@ but has better numerical properties, especially if A is ill-conditioned.
 If `log` is set to `true` is given, method will output a tuple `x, ch`. Where
 `ch` is a `ConvergenceHistory` object. Otherwise it will only return `x`.
 
-The `plot` attribute can only be used when `log` is set version.
-
 # Arguments
 
 $arg
@@ -306,8 +302,6 @@ may then be excessive.
 
 `log::Bool = false`: output an extra element of type `ConvergenceHistory`
 containing extra information of the method execution.
-
-`plot::Bool = false`: plot data. (Only when `log` is set)
 
 # Output
 

--- a/src/lsqr.jl
+++ b/src/lsqr.jl
@@ -7,18 +7,15 @@ export lsqr, lsqr!
 lsqr(A, b; kwargs...) = lsqr!(zerox(A, b), A, b; kwargs...)
 
 function lsqr!(x, A, b;
-    plot::Bool=false, maxiter::Int=max(size(A,1), size(A,2)), log::Bool=false,
+    maxiter::Int=max(size(A,1), size(A,2)), log::Bool=false,
     kwargs...
     )
     T = Adivtype(A, b)
     z = zero(T)
-
-    (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial=!log)
     reserve!(history,[:resnorm,:anorm,:rnorm,:cnorm],maxiter)
     lsqr_method!(history, x, A, b; maxiter=maxiter, kwargs...)
-    (plot || log) && shrink!(history)
-    plot && showplot(history)
+    log && shrink!(history)
     log ? (x, history) : x
 end
 
@@ -262,8 +259,6 @@ but has better numerical properties, especially if A is ill-conditioned.
 If `log` is set to `true` is given, method will output a tuple `x, ch`. Where
 `ch` is a `ConvergenceHistory` object. Otherwise it will only return `x`.
 
-The `plot` attribute can only be used when `log` is set version.
-
 # Arguments
 
 $arg
@@ -295,8 +290,6 @@ may then be excessive.
 
 `log::Bool = false`: output an extra element of type `ConvergenceHistory`
 containing extra information of the method execution.
-
-`plot::Bool = false`: plot data. (Only when `log` is set)
 
 # Output
 

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -7,18 +7,16 @@ export powm, invpowm
 
 function powm(A;
     x=nothing, tol::Real=eps(real(eltype(A)))*size(A,2)^3, maxiter::Int=size(A,2),
-    plot::Bool=false, log::Bool=false, kwargs...
+    log::Bool=false, kwargs...
     )
     K = KrylovSubspace(A, 1)
     x==nothing ? initrand!(K) : init!(K, x/norm(x))
 
-    (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     eig, v = powm_method!(history, K; tol=tol, maxiter=maxiter, kwargs...)
-    (plot || log) && shrink!(history)
-    plot && showplot(history)
+    log && shrink!(history)
     log ? (eig, v, history) : (eig, v)
 end
 
@@ -53,18 +51,16 @@ end
 
 function invpowm(A;
     x=nothing, shift::Number=0, tol::Real=eps(real(eltype(A)))*size(A,2)^3,
-    maxiter::Int=size(A,2), plot::Bool=false, log::Bool=false, kwargs...
+    maxiter::Int=size(A,2), log::Bool=false, kwargs...
     )
     K = KrylovSubspace(A, 1)
     x==nothing ? initrand!(K) : init!(K, x/norm(x))
 
-    (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     eig, v = invpowm_method!(history, K, shift; tol=tol, maxiter=maxiter, kwargs...)
-    (plot || log) && shrink!(history)
-    plot && showplot(history)
+    log && shrink!(history)
     log ? (eig, v, history) : (eig, v)
 end
 
@@ -131,8 +127,6 @@ $msg
 If `log` is set to `true` is given, method will output a tuple `eig, v, ch`. Where
 `ch` is a `ConvergenceHistory` object. Otherwise it will only return `eig, v`.
 
-The `plot` attribute can only be used when `log` is set version.
-
 # Arguments
 
 `K::KrylovSubspace`: krylov subspace.
@@ -153,8 +147,6 @@ $karg
 
 `log::Bool = false`: output an extra element of type `ConvergenceHistory`
 containing extra information of the method execution.
-
-`plot::Bool = false`: plot data. (Only when `log` is set)
 
 # Output
 

--- a/src/stationary.jl
+++ b/src/stationary.jl
@@ -10,15 +10,13 @@ jacobi(A::AbstractMatrix, b; kwargs...) = jacobi!(zerox(A, b), A, b; kwargs...)
 
 function jacobi!(x, A::AbstractMatrix, b;
     tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2,
-    plot::Bool=false, log::Bool=false, kwargs...
+    log::Bool=false, kwargs...
     )
-    (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     jacobi_method!(history, x, A, b; tol=tol, maxiter=maxiter, kwargs...)
-    (plot || log) && shrink!(history)
-    plot && showplot(history)
+    log && shrink!(history)
     log ? (x, history) : x
 end
 
@@ -66,15 +64,13 @@ gauss_seidel(A::AbstractMatrix, b; kwargs...) =
 
 function gauss_seidel!(x, A::AbstractMatrix, b;
     tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2,
-    plot::Bool=false, log::Bool=false, kwargs...
+    log::Bool=false, kwargs...
     )
-    (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     gauss_seidel_method!(history, x, A, b; tol=tol, maxiter=maxiter, kwargs...)
-    (plot || log) && shrink!(history)
-    plot && showplot(history)
+    log && shrink!(history)
     log ? (x, history) : x
 end
 
@@ -125,15 +121,13 @@ sor(A::AbstractMatrix, b, ω::Real; kwargs...) =
 
 function sor!(x, A::AbstractMatrix, b, ω::Real;
     tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2)^2,
-    plot::Bool=false, log::Bool=false, kwargs...
+    log::Bool=false, kwargs...
     )
-    (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     sor_method!(history, x, A, b, ω; tol=tol, maxiter=maxiter, kwargs...)
-    (plot || log) && shrink!(history)
-    plot && showplot(history)
+    log && shrink!(history)
     log ? (x, history) : x
 end
 
@@ -187,15 +181,13 @@ ssor(A::AbstractMatrix, b, ω::Real; kwargs...) =
 
 function ssor!(x, A::AbstractMatrix, b, ω::Real;
     tol=size(A,2)^3*eps(typeof(real(b[1]))), maxiter=size(A,2),
-    plot::Bool=false, log::Bool=false, kwargs...
+    log::Bool=false, kwargs...
     )
-    (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(history,:resnorm, maxiter)
     ssor_method!(history, x, A, b, ω; tol=tol, maxiter=maxiter, kwargs...)
-    (plot || log) && shrink!(history)
-    plot && showplot(history)
+    log && shrink!(history)
     log ? (x, history) : x
 end
 
@@ -314,8 +306,7 @@ $call
 $msg
 
 `ch` is a `ConvergenceHistory` object. Otherwise it will only return `x`.
-If `log` is set to `true` is given, method will output a tuple `x, ch`. Where
-The `plot` attribute can only be used when `log` is set version.
+If `log` is set to `true` is given, method will output a tuple `x, ch`.
 
 # Arguments
 
@@ -333,8 +324,6 @@ $arg
 
 `log::Bool = false`: output an extra element of type `ConvergenceHistory`
 containing extra information of the method execution.
-
-`plot::Bool = false`: plot data. (Only when `log` is set)
 
 # Output
 

--- a/src/svdl.jl
+++ b/src/svdl.jl
@@ -88,8 +88,6 @@ bidiagonalization \cite{Golub1965} with thick restarting \cite{Wu2000}.
 If `log` is set to `true` is given, method will output a tuple `X, L, ch`. Where
 `ch` is a `ConvergenceHistory` object. Otherwise it will only return `X, L`.
 
-The `plot` attribute can only be used when `log` is set version.
-
 # Arguments
 
 `A` : The matrix or matrix-like object whose singular values are desired.
@@ -133,8 +131,6 @@ from the Krylov subspace being searched in the next macroiteration.
 `log::Bool = false`: output an extra element of type `ConvergenceHistory`
 containing extra information of the method execution.
 
-`plot::Bool = false`: plot data. (Only when `log` is set)
-
 # Output
 
 **if `log` is `false`**
@@ -165,10 +161,9 @@ otherwise returns an `SVD` object with the desired singular vectors filled in.
 
 """
 function svdl(A;
-    nsv::Int=6, k::Int=2nsv, plot::Bool=false, tol::Real=√eps(),
+    nsv::Int=6, k::Int=2nsv, tol::Real=√eps(),
     maxiter::Int=minimum(size(A)), method::Symbol=:ritz, log::Bool=false, kwargs...
     )
-    (plot & !log) && error("Can't plot when log keyword is false")
     history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
     reserve!(BitArray, history,:conv, maxiter)
@@ -177,8 +172,7 @@ function svdl(A;
     reserve!(Bs_type, history,:Bs, maxiter)
     reserve!(history,:betas, maxiter)
     X, L = svdl_method!(history, A, nsv; k=k, tol=tol, maxiter=maxiter, method=method, kwargs...)
-    (plot || log) && shrink!(history)
-    plot && showplot(history)
+    log && shrink!(history)
     log ? (X, L, history) : (X, L)
 end
 
@@ -189,7 +183,7 @@ end
 function svdl_method!(log::ConvergenceHistory, A, l::Int=min(6, size(A,1)); k::Int=2l,
     j::Int=l, v0::AbstractVector = Vector{eltype(A)}(randn(size(A, 2))) |> x->scale!(x, inv(norm(x))),
     maxiter::Int=minimum(size(A)), tol::Real=√eps(), reltol::Real=√eps(),
-    verbose::Bool=false, method::Symbol=:ritz, doplot::Bool=false, vecs=:none, dolock::Bool=false)
+    verbose::Bool=false, method::Symbol=:ritz, vecs=:none, dolock::Bool=false)
 
     T0 = time_ns()
     @assert k>1


### PR DESCRIPTION
It's a bit weird to have algorithms do plotting. Doesn't it make more sense to do just

```
x, history = method(...; log = true)
plot(history)
```

rather than

```
x, history = method(...; log = true, plot = true)
```