### PR TITLE
Power method iterators

### DIFF
--- a/src/simple.jl
+++ b/src/simple.jl
@@ -1,3 +1,5 @@
+import Base: start, next, done
+
 #Simple methods
 export powm, invpowm
 
@@ -5,91 +7,109 @@ export powm, invpowm
 # API method calls #
 ####################
 
-function powm(A;
-    x=nothing, tol::Real=eps(real(eltype(A)))*size(A,2)^3, maxiter::Int=size(A,2),
-    log::Bool=false, kwargs...
-    )
-    K = KrylovSubspace(A, 1)
-    x==nothing ? initrand!(K) : init!(K, x/norm(x))
+type PowerMethodIterable{matT, vecT <: AbstractVector, numT <: Number, eigvalT <: Number}
+    A::matT
+    x::vecT
+    tol::numT
+    maxiter::Int
+    θ::eigvalT
+    r::vecT
+    Ax::vecT
+    residual::numT
+end
 
-    history = ConvergenceHistory(partial=!log)
+
+##
+## Iterators
+##
+
+@inline converged(p::PowerMethodIterable) = p.residual < p.tol
+
+@inline start(p::PowerMethodIterable) = 0
+
+@inline done(p::PowerMethodIterable, iteration::Int) = iteration > p.maxiter || converged(p)
+
+function next(p::PowerMethodIterable, iteration::Int)
+
+    A_mul_B!(p.Ax, p.A, p.x)
+
+    # Rayleigh quotient θ = x'Ax
+    p.θ = dot(p.x, p.Ax)
+
+    # (Previous) residual vector r = Ax - λx
+    copy!(p.r, p.Ax)
+    BLAS.axpy!(-p.θ, p.x, p.r)
+
+    # Normed residual
+    p.residual = norm(p.r)
+
+    # Normalize the next approximation
+    copy!(p.x, p.Ax)
+    scale!(p.x, one(eltype(p.x)) / norm(p.x))
+
+    p.residual, iteration + 1
+end
+
+# Transforms the eigenvalue back whether shifted or inversed
+@inline transform_eigenvalue(θ, inverse::Bool, σ) = σ + (inverse ? inv(θ) : θ)
+
+function powm_iterable!(A, x; tol = eps(real(eltype(A))) * size(A, 2) ^ 3, maxiter = size(A, 1))
+    T = eltype(x)
+    PowerMethodIterable(A, x, tol, maxiter, zero(T), similar(x), similar(x), realmax(real(T)))
+end
+
+function powm_iterable(A; kwargs...)
+    x0 = rand(Complex{real(eltype(A))}, size(A, 1))
+    scale!(x0, 1.0 / norm(x0))
+    powm_iterable!(A, x0; kwargs...)
+end
+
+function powm(A; kwargs...)
+    x0 = rand(Complex{real(eltype(A))}, size(A, 1))
+    scale!(x0, 1.0 / norm(x0))
+    powm!(A, x0; kwargs...)
+end
+
+function powm!(A, x;
+    tol = eps(real(eltype(A))) * size(A, 2) ^ 3,
+    maxiter = size(A, 1),
+    shift = zero(eltype(A)),
+    inverse::Bool = false,
+    log::Bool = false,
+    verbose::Bool = false
+)
+    history = ConvergenceHistory(partial = !log)
     history[:tol] = tol
-    reserve!(history,:resnorm, maxiter)
-    eig, v = powm_method!(history, K; tol=tol, maxiter=maxiter, kwargs...)
-    log && shrink!(history)
-    log ? (eig, v, history) : (eig, v)
-end
+    reserve!(history, :resnorm, maxiter)
+    verbose && @printf("=== powm ===\n%4s\t%7s\n", "iter", "resnorm")
 
-#########################
-# Method Implementation #
-#########################
+    iterable = powm_iterable!(A, x, tol = tol, maxiter = maxiter)
 
-function powm_method!{T}(log::ConvergenceHistory, K::KrylovSubspace{T};
-    tol::Real=eps(real(T))*K.n^3, maxiter::Int=K.n, verbose::Bool=false
-    )
-    verbose && @printf("=== powm ===\n%4s\t%7s\n","iter","resnorm")
-    θ = zero(T)
-    v = Array(T, K.n)
-    for iter=1:maxiter
-        nextiter!(log,mvps=1)
-        v = lastvec(K)
-        y = nextvec(K)
-        θ = dot(v, y)
-        resnorm = real(norm(y - θ*v))
-        push!(log, :resnorm, resnorm)
-        verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
-        resnorm <= tol*abs(θ) && (setconv(log, resnorm >= 0); break)
-        appendunit!(K, y)
+    for (iteration, residual) = enumerate(iterable)
+        nextiter!(history, mvps = 1)
+        verbose && @printf("%3d\t%1.2e\n", iteration, residual)
     end
-    verbose && @printf("\n")
-    θ, v
-end
 
-####################
-# API method calls #
-####################
+    setconv(history, converged(iterable))
 
-function invpowm(A;
-    x=nothing, shift::Number=0, tol::Real=eps(real(eltype(A)))*size(A,2)^3,
-    maxiter::Int=size(A,2), log::Bool=false, kwargs...
-    )
-    K = KrylovSubspace(A, 1)
-    x==nothing ? initrand!(K) : init!(K, x/norm(x))
+    println()
 
-    history = ConvergenceHistory(partial=!log)
-    history[:tol] = tol
-    reserve!(history,:resnorm, maxiter)
-    eig, v = invpowm_method!(history, K, shift; tol=tol, maxiter=maxiter, kwargs...)
     log && shrink!(history)
-    log ? (eig, v, history) : (eig, v)
+
+    λ = transform_eigenvalue(iterable.θ, inverse, shift)
+    x = iterable.x
+
+    log ? (λ, x, history) : (λ, x)
 end
 
-#########################
-# Method Implementation #
-#########################
 
-function invpowm_method!{T}(log::ConvergenceHistory, K::KrylovSubspace{T}, σ::Number=zero(T);
-    tol::Real=eps(real(T))*K.n^3, maxiter::Int=K.n, verbose::Bool=false
-    )
-    verbose && @printf("=== invpowm ===\n%4s\t%7s\n","iter","resnorm")
-    θ = zero(T)
-    v = Array(T, K.n)
-    y = Array(T, K.n)
-    σ = convert(T, σ)
-    for iter=1:maxiter
-        nextiter!(log,mvps=1)
-        v = lastvec(K)
-        y = (K.A-σ*eye(K))\v
-        θ = dot(v, y)
-        resnorm = norm(y - θ*v)
-        push!(log, :resnorm, resnorm)
-        verbose && @printf("%3d\t%1.2e\n",iter,resnorm)
-        resnorm <= tol*abs(θ) && (setconv(log, resnorm >= 0); break)
-        appendunit!(K, y)
-    end
-    verbose && @printf("\n")
-    σ+1/θ, y/θ
+function invpowm(A; kwargs...)
+    x0 = rand(Complex{real(eltype(A))}, size(A, 1))
+    scale!(x0, 1.0 / norm(x0))
+    invpowm!(A, x0; kwargs...)
 end
+
+invpowm!(A, x0; kwargs...) = powm!(A, x0; inverse = true, kwargs...)
 
 #################
 # Documentation #

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -60,13 +60,13 @@ end
 
 function powm_iterable(A; kwargs...)
     x0 = rand(Complex{real(eltype(A))}, size(A, 1))
-    scale!(x0, 1.0 / norm(x0))
+    scale!(x0, one(eltype(A)) / norm(x0))
     powm_iterable!(A, x0; kwargs...)
 end
 
 function powm(A; kwargs...)
     x0 = rand(Complex{real(eltype(A))}, size(A, 1))
-    scale!(x0, 1.0 / norm(x0))
+    scale!(x0, one(eltype(A)) / norm(x0))
     powm!(A, x0; kwargs...)
 end
 
@@ -92,7 +92,7 @@ function powm!(A, x;
 
     setconv(history, converged(iterable))
 
-    println()
+    verbose && println()
 
     log && shrink!(history)
 
@@ -105,7 +105,7 @@ end
 
 function invpowm(A; kwargs...)
     x0 = rand(Complex{real(eltype(A))}, size(A, 1))
-    scale!(x0, 1.0 / norm(x0))
+    scale!(x0, one(eltype(A)) / norm(x0))
     invpowm!(A, x0; kwargs...)
 end
 
@@ -121,10 +121,10 @@ doc1_call = """    powm(A)
 """
 doc2_call = """    invpowm(A)
 """
-doc1_msg = """Find biggest eigenvalue of `A` and its associated eigenvector
+doc1_msg = """Find the largest eigenvalue `λ` (in absolute value) of `A` and its associated eigenvector `x`
 using the power method.
 """
-doc2_msg = """Find closest eigenvalue of `A` to `shift` and its associated eigenvector
+doc2_msg = """Find the closest eigenvalue `λ` of `A` to `shift` and its associated eigenvector `x`
 using the inverse power iteration method.
 """
 doc1_karg = ""
@@ -144,8 +144,8 @@ $call
 
 $msg
 
-If `log` is set to `true` is given, method will output a tuple `eig, v, ch`. Where
-`ch` is a `ConvergenceHistory` object. Otherwise it will only return `eig, v`.
+If `log` is set to `true` is given, method will output a tuple `λ, x, ch`. Where
+`ch` is a `ConvergenceHistory` object. Otherwise it will only return `λ, x`.
 
 # Arguments
 
@@ -172,15 +172,15 @@ containing extra information of the method execution.
 
 **if `log` is `false`**
 
-`eig::Real`: eigen value
+`λ::Number`: eigenvalue
 
-`v::Vector`: eigen vector
+`x::Vector`: eigenvector
 
 **if `log` is `true`**
 
-`eig::Real`: eigen value
+`eig::Real`: eigenvalue
 
-`v::Vector`: eigen vector
+`x::Vector`: eigenvector
 
 `ch`: convergence history.
 

--- a/test/simple_eigensolvers.jl
+++ b/test/simple_eigensolvers.jl
@@ -10,31 +10,42 @@ srand(1234321)
 #######################
 
 facts("simple eigensolvers") do
-for T in (Float32, Float64, Complex64, Complex128)
-    context("Matrix{$T}") do
-    A=convert(Matrix{T}, randn(n,n))
-    T<:Complex && (A+=convert(Matrix{T}, im*randn(n,n)))
-    A=A+A' #Symmetric/Hermitian
 
-    tol = (eltype(T) <: Complex ?2:1)*n^2*cond(A)*eps(real(one(T)))
+n = 10
+
+for T in (Float32, Float64, Complex64, Complex128)
+
+    context("Matrix{$T}") do
+
+    A = rand(T, n, n)
+    A = A + A'
+
+    tol = (eltype(T) <: Complex ? 2 : 1) * n^2 * cond(A) * eps(real(one(T)))
     v = eigvals(A)
 
     ## Simple methods
 
     context("Power iteration") do
-    eval_big = maximum(v) > abs(minimum(v)) ? maximum(v) : minimum(v)
-    eval_pow = powm(A; tol=sqrt(eps(real(one(T)))), maxiter=2000)[1]
-    @fact norm(eval_big-eval_pow) --> less_than(tol)
+        eval_big = maximum(v) > abs(minimum(v)) ? maximum(v) : minimum(v)
+        eval_pow = powm(A; tol = sqrt(eps(real(one(T)))), maxiter = 2000)[1]
+        @fact norm(eval_big - eval_pow) --> less_than(tol)
     end
 
     context("Inverse iteration") do
-    irnd = ceil(Int, rand()*(n-2))
-    eval_rand = v[1+irnd] #Pick random eigenvalue
-    # Perturb the eigenvalue by < 1/4 of the distance to the nearest eigenvalue
-    eval_diff = min(abs(v[irnd]-eval_rand), abs(v[irnd+2]-eval_rand))
-    σ = eval_rand + eval_diff/2*(rand()-.5)
-    eval_ii = invpowm(A; shift=σ, tol=sqrt(eps(real(one(T)))), maxiter=2000)[1]
-    @fact norm(eval_rand-eval_ii) --> less_than(tol)
+        irnd = ceil(Int, rand() * (n - 2))
+        eval_rand = v[1 + irnd] #Pick random eigenvalue
+        # Perturb the eigenvalue by < 1/4 of the distance to the nearest eigenvalue
+        eval_diff = min(abs(v[irnd] - eval_rand), abs(v[irnd + 2] - eval_rand))
+        σ = eval_rand + eval_diff / 2 * (rand() - 0.5)
+
+        F = lufact(A - UniformScaling(σ))
+        Fmap = LinearMap((y, x) -> A_ldiv_B!(y, F, x), nothing, size(A, 1), size(A, 2), T, ismutating = true)
+
+        λ, x = invpowm(Fmap; shift = σ, tol = sqrt(eps(real(T))), maxiter = 2000, verbose = true)
+
+        @fact norm(A * x - λ * x) --> less_than(tol)
+        @fact norm(eval_rand - λ) --> less_than(tol)
+
     end
 
     end


### PR DESCRIPTION
As part of getting rid of `KrylovSubspace` and adding iterators as suggested in #129, here the fix for the power method.

There is a breaking change: the shift-and-invert matrix is not constructed in the method itself (and for good reason, otherwise you could just use RQI and get better convergence at the same computational costs per step). It is assumed the user provides a linear map `B` supporting `A_mul_B!`, which has the effect `B * x = inv(A - σI) * x` where σ is the shift. The only convenience `invpowm` gives over `powm` is that the eigenvalue is transformed for you.

For example:

```
using LinearMaps
σ = 1.0 + 1.3im
A = rand(Complex128, 50, 50)
F = lufact(A - UniformScaling(σ))
Fmap = LinearMap((y, x) -> A_ldiv_B!(y, F, x), 50, Complex128, ismutating = true)
λ, x = invpowm(Fmap, shift = σ, tol = 1e-4, maxiter = 200)
```

You might argue `A_ldiv_B!` should be used in `invpowm`, but the thing is someone could just as well have an explicit inverse matrix `inv(A -  σI)`, and then `A_mul_B!` should be used.

Lastly, the method now stores exactly 3 vectors, and those are pre-allocated; the current behaviour is allocating a new matrix each iteration, together with multiple new vectors.