### PR TITLE
Allow 1% threshold for codecov to fail

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto 
+
 comment: off


### PR DESCRIPTION
Typically you get a fail of codecov because of a 0.03% reduction in coverage. The full report then shows that the documentation is not covered. Since not at 100% coverage anyway, maybe it's better to allow a threshold of 1% before failing.