### PR TITLE
MINRES

### DIFF
--- a/benchmark/benchmark-linear-systems.jl
+++ b/benchmark/benchmark-linear-systems.jl
@@ -77,4 +77,12 @@ function bicgstabl()
     b1, b2, b3, b4
 end
 
+function minres(n = 100_000)
+    A = SymTridiagonal(fill(2.1, n), fill(-1.0, n))
+    x = ones(n)
+    b = A * x
+
+    @benchmark IterativeSolvers.minres($A, $b, maxiter = 100)
+end
+
 end

--- a/src/IterativeSolvers.jl
+++ b/src/IterativeSolvers.jl
@@ -21,6 +21,7 @@ include("hessenberg.jl")
 #Linear solvers
 include("stationary.jl")
 include("cg.jl")
+include("minres.jl")
 include("bicgstabl.jl")
 include("gmres.jl")
 include("chebyshev.jl")

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -1,0 +1,175 @@
+export minres_iterable, minres
+
+import Base.LinAlg: BLAS.axpy!, givensAlgorithm
+import Base: start, next, done
+
+"""
+MINRES is full GMRES for Hermetian matrices, finding
+xₖ := x₀ + Vₖyₖ, where Vₖ is an orthonormal basis for
+the Krylov subspace K(A, b - Ax₀). Since
+|rₖ| = |b - Axₖ| = |r₀ - Vₖ₊₁Hₖyₖ| = | |r₀|e₁ - Hₖyₖ|, we solve
+Hₖyₖ = |r₀|e₁ in least-square sense. As the Hessenberg matrix
+is tridiagonal, its QR decomp Hₖ = QₖRₖ has Rₖ with only 3 diagonals,
+easily obtained with Givens rotations. The least-squares problem is
+solved as Hₖ'Hₖyₖ = Hₖ'|r₀|e₁ => yₖ = inv(Rₖ) Qₖ'|r₀|e₁, so
+xₖ := x₀ + [Vₖ inv(Rₖ)] [Qₖ'|r₀|e₁]. Now the main difference with GMRES
+is the placement of the brackets. MINRES computes Wₖ = Vₖ inv(Rₖ) via 3-term
+recurrences, and computes last two terms of Qₖ'|r₀|e₁ as well. That is
+enough to update xₖ each iteration.
+"""
+type MINRESIterable{matT, vecT, realT}
+    A::matT
+    x::vecT
+
+    # Krylov basis vectors
+    v_prev::vecT
+    v_curr::vecT
+    v_next::vecT
+
+    # W = R * inv(V) is computed using 3-term recurrence
+    w_prev::vecT
+    w_curr::vecT
+    w_next::vecT
+
+    # Vector of size 4, holding the active column of the Hessenberg matrix
+    # rhs is just two active values of the right-hand side.
+    R::vecT
+    rhs::vecT
+
+    # Some Givens rotations
+    c_prev::realT
+    s_prev::realT
+    c_curr::realT
+    s_curr::realT
+
+    # The normalization constant of v_prev
+    prev_norm::realT
+
+    # Bookkeeping
+    maxiter::Int
+    tolerance::realT
+    resnorm::realT
+end
+
+minres_iterable(A, b; kwargs...) = minres_iterable!(zeros(b), A, b; initially_zero = true, kwargs...)
+
+function minres_iterable!(x, A, b; initially_zero = false, tol = sqrt(eps(real(eltype(b)))), maxiter = size(A, 1))
+    T = real(eltype(b))
+
+    v_prev = similar(b)
+    v_curr = copy(b)
+    v_next = similar(b)
+    w_prev = similar(b)
+    w_curr = similar(b)
+    w_next = similar(b)
+
+    # For nonzero x's, we must do an MV for the initial residual vec
+    if !initially_zero
+        # Use v_next to store Ax; v_next will soon be overwritten.
+        A_mul_B!(v_next, A, x)
+        axpy!(-one(T), v_next, v_curr)
+    end
+
+    # Last column of the R matrix: QR = H where H is 
+    # the tridiagonal Lanczos matrix.
+    R = zeros(T, 4)
+
+    resnorm = norm(v_curr)
+    reltol = resnorm * tol
+
+    # Last two entries of the right-hand side
+    rhs = [resnorm; zero(T)]
+
+    # Normalize the first Krylov basis vector
+    scale!(v_curr, inv(resnorm))
+
+    # The normalization constant of v_prev (initially zero)
+    prev_norm = zero(T)
+
+    # Givens rotations
+    c_prev, s_prev = one(T), zero(T)
+    c_curr, s_curr = one(T), zero(T)
+
+    MINRESIterable(
+        A, x,
+        v_prev, v_curr, v_next,
+        w_prev, w_curr, w_next,
+        R, rhs,
+        c_prev, s_prev, c_curr, s_curr, prev_norm,
+        maxiter, reltol, resnorm
+    )
+end
+
+converged(m::MINRESIterable) = m.resnorm ≤ m.tolerance
+
+start(::MINRESIterable) = 1
+
+done(m::MINRESIterable, iteration::Int) = iteration > m.maxiter || converged(m)
+
+function next(m::MINRESIterable, iteration::Int)
+    # v_next = A * v_curr - prev_norm * v_prev
+    A_mul_B!(m.v_next, m.A, m.v_curr)
+
+    iteration > 1 && axpy!(-m.prev_norm, m.v_prev, m.v_next)
+    
+    # Orthogonalize w.r.t. v_curr
+    m.R[3] = dot(m.v_curr, m.v_next)
+    axpy!(-m.R[3], m.v_curr, m.v_next)
+
+    # Normalize
+    m.R[4] = m.prev_norm = norm(m.v_next)
+    scale!(m.v_next, inv(m.prev_norm))
+
+    # Rotation on R[1] and R[2]. Note that R[1] = 0 initially
+    if iteration > 2
+        m.R[1] = m.s_prev * m.R[2]
+        m.R[2] = m.c_prev * m.R[2]
+    end
+
+    # Rotation on R[2] and R[3]
+    if iteration > 1
+        tmp = -m.s_curr * m.R[2] + m.c_curr * m.R[3]
+        m.R[2] = m.c_curr * m.R[2] + m.s_curr * m.R[3]
+        m.R[3] = tmp
+    end
+
+    # Next rotation
+    c, s, m.R[3] = givensAlgorithm(m.R[3], m.R[4])
+
+    # Apply as well to the right-hand side
+    m.rhs[2] = -s * m.rhs[1]
+    m.rhs[1] = c * m.rhs[1]
+
+    # Update W = V * inv(R). Two axpy's can maybe be one MV.
+    copy!(m.w_next, m.v_curr)
+    iteration > 1 && axpy!(-m.R[2], m.w_curr, m.w_next)
+    iteration > 2 && axpy!(-m.R[1], m.w_prev, m.w_next)
+    scale!(m.w_next, inv(m.R[3]))
+
+    # Update solution x
+    axpy!(m.rhs[1], m.w_next, m.x)
+
+    # Move on: next -> curr, curr -> prev
+    m.v_prev, m.v_curr, m.v_next = m.v_curr, m.v_next, m.v_prev
+    m.w_prev, m.w_curr, m.w_next = m.w_curr, m.w_next, m.w_prev
+    m.c_prev, m.s_prev, m.c_curr, m.s_curr = m.c_curr, m.s_curr, c, s
+    m.rhs[1] = m.rhs[2]
+
+    # Due to symmetry of the tri-diagonal matrix
+    m.R[2] = m.prev_norm
+
+    # The approximate residual is cheaply available
+    m.resnorm = abs(m.rhs[2])
+
+    m.resnorm, iteration + 1
+end
+
+function minres!(x, A, b; kwargs...)
+    iterable = minres_iterable!(x, A, b; kwargs...)
+
+    for resnorm = iterable end
+
+    iterable.x, iterable.resnorm
+end
+
+minres(A, b; kwargs...) = minres!(zeros(b), A, b; initially_zero = true, kwargs...)

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -174,7 +174,7 @@ function minres!(x, A, b;
     verbose::Bool = false,
     log::Bool = false,
     tol = sqrt(eps(real(eltype(b)))),
-    maxiter::Int = min(20, size(A, 1)),
+    maxiter::Int = min(30, size(A, 1)),
     kwargs...
 )
     history = ConvergenceHistory(partial = !log)
@@ -203,3 +203,73 @@ function minres!(x, A, b;
 end
 
 minres(A, b; kwargs...) = minres!(zerox(A, b), A, b; initially_zero = true, kwargs...)
+
+#################
+# Documentation #
+#################
+
+let
+doc_call = "minres(A, b)"
+doc!_call = "minres!(x, A, b)"
+
+doc_msg = "Using initial guess zeros(b)."
+doc!_msg = "Overwrites `x`."
+
+doc_arg = ""
+doc!_arg = """`x`: initial guess, overwrite final approximation."""
+
+doc_version = (doc_call, doc_msg, doc_arg)
+doc!_version = (doc!_call, doc!_msg, doc!_arg)
+
+docstring = String[]
+
+#Build docs
+for (call, msg, arg) in (doc_version, doc!_version) #Start
+    push!(docstring, 
+"""
+$call
+
+Solve A*x = b for Hermetian matrices A using MINRES. The method is mathematically 
+equivalent to unrestarted GMRES, but exploits symmetry of A, resulting in short
+recurrences requiring only 6 vectors of storage. MINRES might be slightly less
+stable than full GMRES.
+
+$msg
+
+# Arguments
+
+$arg
+
+`A`: linear operator.
+
+`b`: right hand side (vector).
+
+## Keywords
+
+`tol::Real = sqrt(eps(real(eltype(b))))`: tolerance for stopping condition 
+`|r_k| / |r_0| ≤ tol`. Note that the residual is computed only approximately.
+
+`maxiter::Int = min(30, size(A, 1))`: maximum number of iterations.
+
+`verbose::Bool = false` output during the iterations
+
+`log::Bool = false` enables logging, see **Output**.
+
+# Output
+
+**if `log` is `false`**
+
+`x`: approximated solution.
+
+**if `log` is `true`**
+
+`x`: approximated solution.
+
+`ch`: convergence history.
+"""
+    )
+end
+
+@doc docstring[1] -> minres
+@doc docstring[2] -> minres!
+end

--- a/test/minres.jl
+++ b/test/minres.jl
@@ -1,0 +1,47 @@
+using IterativeSolvers
+using FactCheck
+using Base.Test
+using LinearMaps
+
+srand(1234321)
+
+facts("MINRES") do
+
+n = 15
+
+for T in (Float32, Float64, Complex64, Complex128)
+    context("Matrix{$T}") do
+        # Some well-conditioned symmetric matrix for testing
+        A = let 
+            B = rand(T, n, n) + n * eye(n)
+            B + B'
+        end
+
+        x = ones(T, n)
+        b = A * x
+        tol = sqrt(eps(real(T)))
+
+        x_approx, hist = minres(A, b, maxiter = n + 1, tol = tol, log = true)
+
+        @fact norm(b - A * x_approx) / norm(b) --> less_than_or_equal(tol)
+        @fact hist.isconverged --> true
+    end
+
+    context("SparseMatrixCSC{$T}") do
+        A = let
+            B = sprand(n, n, 2 / n)
+            B + B' + speye(n)
+        end
+
+        x = ones(T, n)
+        b = A * x
+        tol = sqrt(eps(real(T)))
+
+        x_approx, hist = minres(A, b, maxiter = n + 1, tol = tol, log = true)
+
+        @fact norm(b - A * x_approx) / norm(b) --> less_than_or_equal(tol)
+        @fact hist.isconverged --> true
+    end
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,9 @@ include("cg.jl")
 #BiCGStab(l)
 include("bicgstabl.jl")
 
+#MINRES
+include("minres.jl")
+
 #GMRES
 include("gmres.jl")
 


### PR DESCRIPTION
MINRES is basically full GMRES exploiting symmetry of the matrix so that it does short recurrences and stores only 6 vectors, requiring constant work per iteration. The current implementation requires 1 MV-product, 5 axpy's, 1 dot, 1 copy, and 3 scale!'s. 

Maybe 2 axpy's can be translated into 1 MV-product, and a `copy` and `scale!` can maybe be combined, but at any rate the current implementation is already nearly optimal.