### PR TITLE
Drop 0.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 os:
     - linux
 julia:
-    - 0.5
     - 0.6
     - nightly
 matrix:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 
 UnicodePlots
 RecipesBase

--- a/benchmark/setup-florida.jl
+++ b/benchmark/setup-florida.jl
@@ -3,8 +3,6 @@
 #Benchmark iterative methods against matrices from the University of Florida
 #sparse collection
 
-VERSION ≥ v"0.4" || error("Julia 0.4 required")
-
 #Root URL to the matrix collection
 UFL_URL_ROOT = "http://www.cise.ufl.edu/research/sparse/matrices"
 #Plain text file containing list of matrices

--- a/src/svdl.jl
+++ b/src/svdl.jl
@@ -480,11 +480,7 @@ function harmonicrestart!{T,Tr}(A, L::PartialFactorization{T,Tr},
 
 
     #Construct broken arrow matrix
-    if VERSION < v"0.5.0-"
-        BA = [diagm(F0[:S]) ρ']
-    else #slicing behavior changed in 0.5
-        BA = [diagm(F0[:S]) ρ]
-    end
+    BA = [diagm(F0[:S]) ρ]
     F2 = svdfact!(BA, thin=false)
 
     #Take k largest triplets
@@ -520,11 +516,7 @@ function harmonicrestart!{T,Tr}(A, L::PartialFactorization{T,Tr},
     Q = L.Q*Q
     P = L.P*view(U,:,1:k)
 
-    if VERSION < v"0.5.0-"
-        R = view(R,1:k+1,1:k) + view(R,:,k+1)*Mend
-    else
-        R = view(R,1:k+1,1:k) + view(R,:,k+1)*Mend'
-    end
+    R = view(R,1:k+1,1:k) + view(R,:,k+1)*Mend'
 
     f = A*view(Q,:,k+1)
     f -= P*(P'f)


### PR DESCRIPTION
Since LinearMaps already dropped support for Julia 0.5, and only critical fixes are backported to 0.5, it might be worthwhile to drop support for 0.5 altogether. 

This makes it also possible to silence the number of deprecation warnings.