### PR TITLE
Modernize syntax

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,4 +4,3 @@ UnicodePlots
 RecipesBase
 SugarBLAS
 LinearMaps
-Compat 0.18.0

--- a/src/IterativeSolvers.jl
+++ b/src/IterativeSolvers.jl
@@ -7,8 +7,6 @@ module IterativeSolvers
 
 using SugarBLAS
 
-using Compat
-
 include("common.jl")
 include("orthogonalize.jl")
 include("history.jl")

--- a/src/bicgstabl.jl
+++ b/src/bicgstabl.jl
@@ -2,7 +2,7 @@ export bicgstabl, bicgstabl!, bicgstabl_iterator, bicgstabl_iterator!, BiCGStabI
 
 import Base: start, next, done
 
-type BiCGStabIterable{precT, matT, vecT <: AbstractVector, smallMatT <: AbstractMatrix, realT <: Real, scalarT <: Number}
+mutable struct BiCGStabIterable{precT, matT, vecT <: AbstractVector, smallMatT <: AbstractMatrix, realT <: Real, scalarT <: Number}
     A::matT
     b::vecT
     l::Int

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -2,7 +2,7 @@ import Base: start, next, done
 
 export cg, cg!, CGIterable, PCGIterable, cg_iterator, cg_iterator!
 
-type CGIterable{matT, vecT <: AbstractVector, numT <: Real}
+mutable struct CGIterable{matT, vecT <: AbstractVector, numT <: Real}
     A::matT
     x::vecT
     b::vecT
@@ -16,7 +16,7 @@ type CGIterable{matT, vecT <: AbstractVector, numT <: Real}
     mv_products::Int
 end
 
-type PCGIterable{precT, matT, vecT <: AbstractVector, numT <: Real, paramT <: Number}
+mutable struct PCGIterable{precT, matT, vecT <: AbstractVector, numT <: Real, paramT <: Number}
     Pl::precT
     A::matT
     x::vecT

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -2,7 +2,7 @@ import Base: next, start, done
 
 export chebyshev, chebyshev!
 
-type ChebyshevIterable{precT, matT, vecT, realT <: Real}
+mutable struct ChebyshevIterable{precT, matT, vecT, realT <: Real}
     Pl::precT
     A::matT
     b::vecT

--- a/src/common.jl
+++ b/src/common.jl
@@ -47,10 +47,10 @@ solve(A::Function,b) = A(b)
 
 solve(A,b) = A\b
 
-solve!{T}(out::AbstractArray{T},A::Int,b::AbstractArray{T}) = scale!(out,b, 1/A)
+solve!(out::AbstractArray{T},A::Int,b::AbstractArray{T}) where {T} = scale!(out,b, 1/A)
 
-solve!{T}(out::AbstractArray{T},A,b::AbstractArray{T}) = A_ldiv_B!(out,A,b)
-solve!{T}(out::AbstractArray{T},A::Function,b::AbstractArray{T}) = copy!(out,A(b))
+solve!(out::AbstractArray{T},A,b::AbstractArray{T}) where {T} = A_ldiv_B!(out,A,b)
+solve!(out::AbstractArray{T},A::Function,b::AbstractArray{T}) where {T} = copy!(out,A(b))
 
 """
     initrand!(v)
@@ -76,7 +76,7 @@ type PosSemidefException <: Exception
 end
 
 # Identity preconditioner
-immutable Identity end
+struct Identity end
 
 Base.:\(::Identity, x) = copy(x)
 Base.A_ldiv_B!(::Identity, x) = x

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,9 +1,8 @@
-import  Base: eltype, length, ndims, real, size, *,
-        A_mul_B!, Ac_mul_B, Ac_mul_B!
+import Base: A_ldiv_B!, \
 
-using   LinearMaps, Compat
+using LinearMaps, Compat
 
-export  A_mul_B, Identity
+export Identity
 
 #### Type-handling
 """
@@ -67,17 +66,9 @@ end
 _randn!(v::Array{Float64}) = randn!(v)
 _randn!(v) = copy!(v, randn(length(v)))
 
-#### Errors
-export PosSemidefException
-
-type PosSemidefException <: Exception
-    msg :: AbstractString
-    PosSemidefException(msg::AbstractString="Matrix was not positive semidefinite") = new(msg)
-end
-
 # Identity preconditioner
 struct Identity end
 
-Base.:\(::Identity, x) = copy(x)
-Base.A_ldiv_B!(::Identity, x) = x
-Base.A_ldiv_B!(y, ::Identity, x) = copy!(y, x)
+\(::Identity, x) = copy(x)
+A_ldiv_B!(::Identity, x) = x
+A_ldiv_B!(y, ::Identity, x) = copy!(y, x)

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,6 +1,6 @@
 import Base: A_ldiv_B!, \
 
-using LinearMaps, Compat
+using LinearMaps
 
 export Identity
 

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -14,7 +14,7 @@ and `P` computed by `idfact()`. See the documentation of `idfact()` for details.
 
 \\cite{Cheng2005, Liberty2007}
 """
-immutable Interpolative{T} <: Factorization{T}
+struct Interpolative{T} <: Factorization{T}
     B :: AbstractMatrix{T}
     P :: AbstractMatrix{T}
 end

--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -1,7 +1,7 @@
 import Base.LinAlg: Givens, givensAlgorithm
 import Base.A_ldiv_B!
 
-type Hessenberg{T<:AbstractMatrix}
+mutable struct Hessenberg{T<:AbstractMatrix}
     H::T # H is assumed to be Hessenberg of size (m + 1) × m
 end
 

--- a/src/history.jl
+++ b/src/history.jl
@@ -51,7 +51,7 @@ ploted as series and matrices as scatterplots.
 `Base`: `getindex`, `setindex!`, `push!`
 
 """
-type ConvergenceHistory{T,K}
+mutable struct ConvergenceHistory{T,K}
     mvps::Int
     mtvps::Int
     iters::Int
@@ -68,22 +68,22 @@ end
 """
 Stores information of the current iteration.
 """
-@compat const PartialHistory = ConvergenceHistory{false}
+const PartialHistory = ConvergenceHistory{false}
 
 """
 Stores the information of all the iterations.
 """
-@compat const CompleteHistory = ConvergenceHistory{true}
+const CompleteHistory = ConvergenceHistory{true}
 
 """
 History without resets.
 """
-@compat const UnrestartedHistory{T} = ConvergenceHistory{T, Void}
+const UnrestartedHistory{T} = ConvergenceHistory{T, Void}
 
 """
 History with resets.
 """
-@compat const RestartedHistory{T} = ConvergenceHistory{T, Int}
+const RestartedHistory{T} = ConvergenceHistory{T, Int}
 
 
 #############
@@ -256,8 +256,8 @@ nrests(ch::RestartedHistory) = Int(ceil(ch.iters/ch.restart))
 Determine whether a collection `x` is plotable. Only vectors and matrices are
 such objects.
 """
-plotable{T<:Real}(::VecOrMat{T})::Bool = true
-plotable(::Any)::Bool = false
+plotable(::VecOrMat{T}) where {T <: Real} = true
+plotable(::Any) = false
 
 # inner plots
 
@@ -286,10 +286,10 @@ Build a `UnicodePlot.Plot` object from the plotable collection `x`.
 If `x` is a vector, a series will be made. In case of being a matrix an scatterplot
 will be returned.
 """
-function plot_collection{T<:Real}(vals::Vector{T}, iters::Int, gap::Int;
+function plot_collection(vals::Vector{T}, iters::Int, gap::Int;
     restarts=Int(ceil(iters/gap)), color::Symbol=:blue, name::AbstractString="",
     title::AbstractString="", left::Int=1
-    )
+    ) where {T <: Real}
     maxy = round(maximum(vals),2)
     miny = round(minimum(vals),2)
     plot = lineplot([left],[miny],xlim=[left,iters],ylim=[miny,maxy],title=title,name=name)
@@ -303,10 +303,10 @@ function plot_collection{T<:Real}(vals::Vector{T}, iters::Int, gap::Int;
     end
     plot
 end
-function plot_collection{T<:Real}(vals::Matrix{T}, iters::Int, gap::Int;
+function plot_collection(vals::Matrix{T}, iters::Int, gap::Int;
     restarts=Int(ceil(iters/gap)), color::Symbol=:blue, name::AbstractString="",
     title::AbstractString="", left::Int=1
-    )
+    ) where {T <: Real}
     n = size(vals,2)
     maxy = round(maximum(vals),2)
     miny = round(minimum(vals),2)

--- a/src/idrs.jl
+++ b/src/idrs.jl
@@ -44,9 +44,9 @@ subspace algorithms for solving large nonsymmetric linear systems. The idea
 behind the IDR(s) variant is to generate residuals that are in the nested
 subspaces of shrinking dimensions.
 """
-function idrs_method!{T}(log::ConvergenceHistory, X, op, args, C::T,
+function idrs_method!(log::ConvergenceHistory, X, op, args, C::T,
     s::Number, tol::Number, maxiter::Number; smoothing::Bool=false, verbose::Bool=false
-    )
+    ) where {T}
 
     verbose && @printf("=== idrs ===\n%4s\t%7s\n","iter","resnorm")
     R = C - op(X, args...)::T

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -20,7 +20,7 @@ The active column of the Hessenberg matrix H is updated in place to form the
 active column of R. Note that for Hermitian matrices the H matrix is purely
 real, while for skew-Hermitian matrices its diagonal is purely imaginary.
 """
-type MINRESIterable{matT, vecT <: DenseVector, smallVecT <: DenseVector, rotT <: Number, realT <: Real}
+mutable struct MINRESIterable{matT, vecT <: DenseVector, smallVecT <: DenseVector, rotT <: Number, realT <: Real}
     A::matT
     skew_hermitian::Bool
     x::vecT

--- a/src/orthogonalize.jl
+++ b/src/orthogonalize.jl
@@ -1,15 +1,15 @@
 export DGKS, ClassicalGramSchmidt, ModifiedGramSchmidt
 export orthogonalize_and_normalize!
 
-abstract OrthogonalizationMethod
-immutable DGKS <: OrthogonalizationMethod end
-immutable ClassicalGramSchmidt <: OrthogonalizationMethod end
-immutable ModifiedGramSchmidt <: OrthogonalizationMethod end
+abstract type OrthogonalizationMethod end
+struct DGKS <: OrthogonalizationMethod end
+struct ClassicalGramSchmidt <: OrthogonalizationMethod end
+struct ModifiedGramSchmidt <: OrthogonalizationMethod end
 
 # Default to MGS, good enough for solving linear systems.
-@inline orthogonalize_and_normalize!{T}(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}) = orthogonalize_and_normalize!(V, w, h, ModifiedGramSchmidt)
+@inline orthogonalize_and_normalize!(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}) where {T} = orthogonalize_and_normalize!(V, w, h, ModifiedGramSchmidt)
 
-function orthogonalize_and_normalize!{T}(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}, ::Type{DGKS})
+function orthogonalize_and_normalize!(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}, ::Type{DGKS}) where {T}
     # Orthogonalize using BLAS-2 ops
     Ac_mul_B!(h, V, w)
     BLAS.gemv!('N', -one(T), V, h, one(T), w)
@@ -37,7 +37,7 @@ function orthogonalize_and_normalize!{T}(V::StridedMatrix{T}, w::StridedVector{T
     nrm
 end
 
-function orthogonalize_and_normalize!{T}(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}, ::Type{ClassicalGramSchmidt})
+function orthogonalize_and_normalize!(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}, ::Type{ClassicalGramSchmidt}) where {T}
     # Orthogonalize using BLAS-2 ops
     Ac_mul_B!(h, V, w)
     BLAS.gemv!('N', -one(T), V, h, one(T), w)
@@ -49,7 +49,7 @@ function orthogonalize_and_normalize!{T}(V::StridedMatrix{T}, w::StridedVector{T
     nrm
 end
 
-function orthogonalize_and_normalize!{T}(V::StridedVector{Vector{T}}, w::StridedVector{T}, h::StridedVector{T}, ::Type{ModifiedGramSchmidt})
+function orthogonalize_and_normalize!(V::StridedVector{Vector{T}}, w::StridedVector{T}, h::StridedVector{T}, ::Type{ModifiedGramSchmidt}) where {T}
     # Orthogonalize using BLAS-1 ops
     for i = 1 : length(V)
         h[i] = dot(V[i], w)
@@ -63,7 +63,7 @@ function orthogonalize_and_normalize!{T}(V::StridedVector{Vector{T}}, w::Strided
     nrm
 end
 
-function orthogonalize_and_normalize!{T}(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}, ::Type{ModifiedGramSchmidt})
+function orthogonalize_and_normalize!(V::StridedMatrix{T}, w::StridedVector{T}, h::StridedVector{T}, ::Type{ModifiedGramSchmidt}) where {T}
     # Orthogonalize using BLAS-1 ops and column views.
     for i = 1 : size(V, 2)
         column = view(V, :, i)

--- a/src/rlinalg.jl
+++ b/src/rlinalg.jl
@@ -4,6 +4,8 @@
 
 export rcond, reigmax, reigmin, rnorm, rnorms
 
+import Base: *
+
 
 """
     randnn(el, m)

--- a/src/rlinalg.jl
+++ b/src/rlinalg.jl
@@ -322,7 +322,7 @@ A subsampled random Fourier transform.
 
 `Base`: `*`
 """
-immutable srft{T<:Integer}
+struct srft{T<:Integer}
     l :: T
 end
 

--- a/src/rsvd_fnkz.jl
+++ b/src/rsvd_fnkz.jl
@@ -1,7 +1,7 @@
 
 export rsvd_fnkz
 
-immutable OuterProduct{T}
+struct OuterProduct{T}
     X :: Matrix{T}
     Y :: Matrix{T}
 end

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -3,7 +3,7 @@ import Base: start, next, done
 #Simple methods
 export powm, invpowm
 
-type PowerMethodIterable{matT, vecT <: AbstractVector, numT <: Number, eigvalT <: Number}
+mutable struct PowerMethodIterable{matT, vecT <: AbstractVector, numT <: Number, eigvalT <: Number}
     A::matT
     x::vecT
     tol::numT
@@ -134,7 +134,7 @@ using LinearMaps
 σ = 1.0 + 1.3im
 A = rand(Complex128, 50, 50)
 F = lufact(A - UniformScaling(σ))
-Fmap = LinearMap((y, x) -> A_ldiv_B!(y, F, x), 50, Complex128, ismutating = true)
+Fmap = LinearMap{Complex128}((y, x) -> A_ldiv_B!(y, F, x), 50, ismutating = true)
 λ, x = invpowm(Fmap, shift = σ, tol = 1e-4, maxiter = 200)
 ```
 """

--- a/src/stationary.jl
+++ b/src/stationary.jl
@@ -43,7 +43,7 @@ function jacobi_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b;
 			for j=[1:i-1;i+1:n]
 				xi += A[i,j]*xold[j]
 			end
-			A[i,i]==0 && throw(SingularException(1))
+			A[i,i]==0 && throw(SingularException(i))
 			x[i]=(b[i]-xi)/A[i,i]
 		end
 		#check convergence
@@ -100,7 +100,7 @@ function gauss_seidel_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b;
 			for j=i+1:n
 				σ+=A[i,j]*xold[j]
 			end
-			A[i,i]==0 && throw(SingularException(1))
+			A[i,i]==0 && throw(SingularException(i))
 			x[i]=(b[i]-σ)/A[i,i]
 		end
 		#check convergence
@@ -159,7 +159,7 @@ function sor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real;
 			for j=i+1:n
 				σ+=A[i,j]*xold[j]
 			end
-			A[i,i]==0 && throw(SingularException(1))
+			A[i,i]==0 && throw(SingularException(i))
 			σ=(b[i]-σ)/A[i,i]
 			x[i]=xold[i]+ω*(σ-xold[i])
 		end
@@ -219,7 +219,7 @@ function ssor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real
 			for j=i+1:n
 				σ+=A[i,j]*xold[j]
 			end
-			A[i,i]==0 && throw(SingularException(1))
+			A[i,i]==0 && throw(SingularException(i))
 			σ=(b[i]-σ)/A[i,i]
 			x[i]=xold[i]+ω*(σ-xold[i])
 		end
@@ -232,7 +232,7 @@ function ssor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real
 			for j=i+1:n
 				σ+=A[i,j]*x[j]
 			end
-			A[i,i]==0 && throw(SingularException(1))
+			A[i,i]==0 && throw(SingularException(i))
 			σ=(b[i]-σ)/A[i,i] #This line is missing in the Templates reference
 			x[i]=xold[i]+ω*(σ-xold[i])
 		end

--- a/src/stationary.jl
+++ b/src/stationary.jl
@@ -2,6 +2,8 @@
 #Templates, section 2.2
 export jacobi, jacobi!, gauss_seidel, gauss_seidel!, sor, sor!, ssor, ssor!
 
+import Base.LinAlg.SingularException
+
 ####################
 # API method calls #
 ####################
@@ -41,7 +43,7 @@ function jacobi_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b;
 			for j=[1:i-1;i+1:n]
 				xi += A[i,j]*xold[j]
 			end
-			A[i,i]==0 && throw(SingularError())
+			A[i,i]==0 && throw(SingularException(1))
 			x[i]=(b[i]-xi)/A[i,i]
 		end
 		#check convergence
@@ -98,7 +100,7 @@ function gauss_seidel_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b;
 			for j=i+1:n
 				σ+=A[i,j]*xold[j]
 			end
-			A[i,i]==0 && throw(SingularError())
+			A[i,i]==0 && throw(SingularException(1))
 			x[i]=(b[i]-σ)/A[i,i]
 		end
 		#check convergence
@@ -157,7 +159,7 @@ function sor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real;
 			for j=i+1:n
 				σ+=A[i,j]*xold[j]
 			end
-			A[i,i]==0 && throw(SingularError())
+			A[i,i]==0 && throw(SingularException(1))
 			σ=(b[i]-σ)/A[i,i]
 			x[i]=xold[i]+ω*(σ-xold[i])
 		end
@@ -217,7 +219,7 @@ function ssor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real
 			for j=i+1:n
 				σ+=A[i,j]*xold[j]
 			end
-			A[i,i]==0 && throw(SingularError())
+			A[i,i]==0 && throw(SingularException(1))
 			σ=(b[i]-σ)/A[i,i]
 			x[i]=xold[i]+ω*(σ-xold[i])
 		end
@@ -230,7 +232,7 @@ function ssor_method!(log::ConvergenceHistory, x, A::AbstractMatrix, b, ω::Real
 			for j=i+1:n
 				σ+=A[i,j]*x[j]
 			end
-			A[i,i]==0 && throw(SingularError())
+			A[i,i]==0 && throw(SingularException(1))
 			σ=(b[i]-σ)/A[i,i] #This line is missing in the Templates reference
 			x[i]=xold[i]+ω*(σ-xold[i])
 		end

--- a/src/svdl.jl
+++ b/src/svdl.jl
@@ -12,7 +12,7 @@ Matrix of the form
                         d_k
 ```
 """
-type BrokenArrowBidiagonal{T} <: AbstractMatrix{T}
+mutable struct BrokenArrowBidiagonal{T} <: AbstractMatrix{T}
     dv::Vector{T}
     av::Vector{T}
     ev::Vector{T}
@@ -68,7 +68,7 @@ Partial factorization object which is an approximation of a matrix
 
     A ≈ P * [B 0; 0 β] * Q
 """
-type PartialFactorization{T, Tr} <: Factorization{T}
+mutable struct PartialFactorization{T, Tr} <: Factorization{T}
     P :: Matrix{T}
     Q :: Matrix{T}
     B :: AbstractMatrix{Tr}
@@ -402,7 +402,7 @@ function isconverged(L::PartialFactorization, F::Base.LinAlg.SVD, k::Int, tol::R
 end
 
 #Hernandez2008
-function build{T}(log::ConvergenceHistory, A, q::AbstractVector{T}, k::Int)
+function build(log::ConvergenceHistory, A, q::AbstractVector{T}, k::Int) where {T}
     m, n = size(A)
     Tr = typeof(real(one(T)))
     β = norm(q)
@@ -427,8 +427,8 @@ Thick restart (with ordinary Ritz values)
 
 """
 #Hernandez2008
-function thickrestart!{T,Tr}(A, L::PartialFactorization{T,Tr},
-        F::Base.LinAlg.SVD{Tr,Tr}, l::Int)
+function thickrestart!(A, L::PartialFactorization{T,Tr},
+        F::Base.LinAlg.SVD{Tr,Tr}, l::Int) where {T,Tr}
 
     k = size(F[:V], 1)
     m, n = size(A)
@@ -469,8 +469,8 @@ Thick restart with harmonic Ritz values.
 which follows that of [Hernandez2008]
 
 """
-function harmonicrestart!{T,Tr}(A, L::PartialFactorization{T,Tr},
-        F::Base.LinAlg.SVD{Tr,Tr}, k::Int)
+function harmonicrestart!(A, L::PartialFactorization{T,Tr},
+        F::Base.LinAlg.SVD{Tr,Tr}, k::Int) where {T,Tr}
 
     m = size(L.B, 1)::Int
     #@assert size(L.P,2)==m==size(L.Q,2)-1
@@ -606,10 +606,10 @@ which case it will be necessary to orthogonalize both sets of vectors. See
 }
 ```
 """
-function extend!{T,Tr}(
+function extend!(
     log::ConvergenceHistory, A, L::PartialFactorization{T, Tr}, k::Int,
     orthleft::Bool=false, orthright::Bool=true, α::Real = 1/√2
-    )
+    ) where {T,Tr}
 
     l = size(L.B, 2)::Int-1
     p = L.P[:,l+1]

--- a/src/svdl.jl
+++ b/src/svdl.jl
@@ -1,5 +1,7 @@
 export svdl
 
+import Base: size, getindex, full, svdfact
+
 """
 Matrix of the form
 ```
@@ -18,8 +20,9 @@ mutable struct BrokenArrowBidiagonal{T} <: AbstractMatrix{T}
     ev::Vector{T}
 end
 
-Base.size(B::BrokenArrowBidiagonal) = (n=length(B.dv); (n, n))
-function Base.size(B::BrokenArrowBidiagonal, n::Int)
+size(B::BrokenArrowBidiagonal) = (n=length(B.dv); (n, n))
+
+function size(B::BrokenArrowBidiagonal, n::Int)
     if n==1 || n==2
         return length(B.dv)
     else
@@ -27,7 +30,7 @@ function Base.size(B::BrokenArrowBidiagonal, n::Int)
     end
 end
 
-function Base.getindex{T}(B::BrokenArrowBidiagonal{T}, i::Int, j::Int)
+function getindex(B::BrokenArrowBidiagonal{T}, i::Int, j::Int) where {T}
     n = size(B, 1)
     k = length(B.av)
     if !(1 ≤ i ≤ n && 1 ≤ j ≤ n)
@@ -45,7 +48,7 @@ function Base.getindex{T}(B::BrokenArrowBidiagonal{T}, i::Int, j::Int)
     end
 end
 
-function Base.full{T}(B::BrokenArrowBidiagonal{T})
+function full(B::BrokenArrowBidiagonal{T}) where {T}
     n = size(B, 1)
     k = length(B.av)
     M = zeros(T, n, n)
@@ -61,7 +64,7 @@ function Base.full{T}(B::BrokenArrowBidiagonal{T})
     M
 end
 
-Base.svdfact(B::BrokenArrowBidiagonal) = svdfact(full(B)) #XXX This can be much faster
+svdfact(B::BrokenArrowBidiagonal) = svdfact(full(B)) #XXX This can be much faster
 
 """
 Partial factorization object which is an approximation of a matrix

--- a/test/stationary.jl
+++ b/test/stationary.jl
@@ -47,11 +47,11 @@ srand(1234321)
     b = rand(3, 3)
 
     for solver in (jacobi, gauss_seidel)
-        @fact_throws Base.LinAlg.SingularException solver(A, b)
+        @test_throws Base.LinAlg.SingularException solver(A, b)
     end
 
     for solver in (sor, ssor)
-        @fact_throws Base.LinAlg.SingularException solver(A, b, 0.5)
+        @test_throws Base.LinAlg.SingularException solver(A, b, 0.5)
     end
 end
 end

--- a/test/stationary.jl
+++ b/test/stationary.jl
@@ -3,6 +3,8 @@ using Base.Test
 
 @testset "Stationary solvers" begin
 
+import Base.LinAlg.SingularException
+
 n = 10
 m = 6
 ω = 0.5
@@ -38,6 +40,18 @@ srand(1234321)
         xi, history = solver(copy(x0), A, b, ω, maxiter=100, tol=tol, log=true)
         @test history.isconverged
         @test norm(b - A * xi) / norm(b) ≤ tol
+    end
+
+    # Check whether the methods throw when the diagonal has zeros
+    A = [0.0 1.0; 1.0 0.0]
+    b = rand(3, 3)
+
+    for solver in (jacobi, gauss_seidel)
+        @fact_throws Base.LinAlg.SingularException solver(A, b)
+    end
+
+    for solver in (sor, ssor)
+        @fact_throws Base.LinAlg.SingularException solver(A, b, 0.5)
     end
 end
 end


### PR DESCRIPTION
Just use the Julia 0.6 syntax everywhere.

One bug fix in this PR: the stationary solvers used `SingularError` which is probably removed long ago. I'm now using `Base.LinAlg.SingularException` and added a test for it.