### PR TITLE
Use 0.6 to deploy the docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -39,6 +39,8 @@ makedocs(
 deploydocs(
 	repo = "github.com/JuliaMath/IterativeSolvers.jl",
 	target = "build",
+	osname = "linux",
+	julia  = "0.6",
 	deps = nothing,
 	make = nothing,
 )


### PR DESCRIPTION
That's probably the reason the docs haven't been published yet.