### PR TITLE
Remove dependencies on UnicodePlots and LinearMaps

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,3 @@ julia 0.6
 
 RecipesBase
 SugarBLAS
-LinearMaps

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,5 @@
 julia 0.6
 
-UnicodePlots
 RecipesBase
 SugarBLAS
 LinearMaps

--- a/docs/src/about/CONTRIBUTING.md
+++ b/docs/src/about/CONTRIBUTING.md
@@ -42,10 +42,7 @@ other git branches will let you use/test whatever there is.
 
 ## Adding or modifying iterative methods
 
-Each iterative method method must log information using the inner `ConvergenceHistory`
-type. When information is not necessary to be stored (plot is set to `false`) then
-instead of `ConvergenceHistory` create a `DummyHistory`, this type has the same
-calls `ConvergenceHistory` does but without storing anything.
+Each iterative method method must log information using the inner `ConvergenceHistory` type.
 
 There are two types of `ConvergenceHistory`: plain and restarted. The only real
 difference between the two is how they are plotted and how the number of restarts

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,7 +1,5 @@
 import Base: A_ldiv_B!, \
 
-using LinearMaps
-
 export Identity
 
 #### Type-handling

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,1 @@
-Plots
-UnicodePlots
 LinearMaps

--- a/test/history.jl
+++ b/test/history.jl
@@ -1,5 +1,68 @@
 using IterativeSolvers
+using RecipesBase
+using Base.Test
 
 @testset "ConvergenceHistory" begin
 
+    const KW = Dict{Symbol, Any}
+
+    RecipesBase.is_key_supported(k::Symbol) = k == :sep ? false : true
+
+    # No plottables
+    begin
+        history = ConvergenceHistory(partial = false)
+        @test_throws ErrorException RecipesBase.apply_recipe(KW(), history)
+    end
+
+    # Without restart markers
+    begin
+        history = ConvergenceHistory(partial = false)
+        history.iters = 3
+        history.data[:resnorm] = [10.0, 3.0, 0.1]
+        
+        plots = (
+            RecipesBase.apply_recipe(KW(), history),
+            RecipesBase.apply_recipe(KW(), history, :resnorm)
+        )
+
+        for data in plots
+            @test length(data) == 1
+            @test data[1].d[:label] == "resnorm"
+            @test data[1].d[:seriestype] == :line
+        end
+    end
+
+    # With restart markers
+    begin
+        history = ConvergenceHistory(partial = false, restart = 2)
+        history.iters = 3
+        history.data[:resnorm] = [10.0, 3.0, 0.1]
+
+        plots = (
+            RecipesBase.apply_recipe(KW(), history),
+            RecipesBase.apply_recipe(KW(), history, :resnorm)
+        )
+
+        for data in plots
+            @test length(data) == 2
+            @test data[2].d[:linecolor] == :white    
+        end
+    end
+
+    # Custom color
+    begin
+        history = ConvergenceHistory(partial = false, restart = 2)
+        history.iters = 3
+        history.data[:resnorm] = [10.0, 3.0, 0.1]
+
+        plots = (
+            RecipesBase.apply_recipe(KW(:sep => :red), history),
+            RecipesBase.apply_recipe(KW(:sep => :red), history, :resnorm)
+        )
+
+        for data in plots
+            @test length(data) == 2
+            @test data[2].d[:linecolor] == :red
+        end
+    end
 end

--- a/test/history.jl
+++ b/test/history.jl
@@ -1,24 +1,5 @@
 using IterativeSolvers
-using Plots
 
-#Just check it doesn't crash
 @testset "ConvergenceHistory" begin
 
-srand(1234321)
-
-#Use UnicodePlots backend because it is the lightest
-unicodeplots()
-
-A = lu(rand(10, 10))[1]
-b = rand(10)
-
-for solver in (cg, gmres, minres, lsqr, lsmr, idrs)
-    plot(solver(A, b; log=true)[2])
-end
-
-plot(bicgstabl(A, b, 2, log=true)[2])
-plot(chebyshev(A, b, 0.5, 1.5; log=true)[2])
-plot(powm(A; log=true)[2])
-plot(invpowm(A; log=true)[2])
-plot(svdl(A; log=true)[3])
 end


### PR DESCRIPTION
Closes #172.

UnicodePlots can be removed since there is a plot recipe already.

LinearMaps is only a test dependency.