### PR TITLE
Make convergence history show a summary

### DIFF
--- a/src/history.jl
+++ b/src/history.jl
@@ -1,6 +1,6 @@
 using RecipesBase
 
-import Base: getindex, setindex!, push!, keys
+import Base: getindex, setindex!, push!, keys, show
 
 export ConvergenceHistory
 export nprods, niters, nrests
@@ -89,6 +89,11 @@ const RestartedHistory{T} = ConvergenceHistory{T, Int}
 #############
 # Functions #
 #############
+
+function show(io::IO, ch::ConvergenceHistory)
+    print(io, ch.isconverged ? "Converged" : "Not converged",
+        " after ", ch.iters, " iterations.")
+end
 
 """
     getindex(ch, s)

--- a/test/history.jl
+++ b/test/history.jl
@@ -8,6 +8,15 @@ using Base.Test
 
     RecipesBase.is_key_supported(k::Symbol) = k == :sep ? false : true
 
+    begin
+        history = ConvergenceHistory(partial = false)
+        history.iters = 3
+        history.isconverged = true
+        @test string(history) == "Converged after 3 iterations."
+        history.isconverged = false
+        @test string(history) == "Not converged after 3 iterations."
+    end
+
     # No plottables
     begin
         history = ConvergenceHistory(partial = false)


### PR DESCRIPTION
Not sure why we didn't have this earlier.

This PR:

```julia
> cg(rand(4,4), rand(4), log = true)
([-3.22485, -2.92047, 11.985, -11.0404], Not converged after 4 iterations.)
```

Previously:

```julia
> cg(rand(4,4), rand(4), log = true)
([0.809221, -1.30579, 0.895052, 0.603624], IterativeSolvers.ConvergenceHistory{true,Void}(4, 0, 4, nothing, false, Dict{Symbol,Any}(Pair{Symbol,Any}(:tol, 1.49012e-8),Pair{Symbol,Any}(:resnorm, [0.510782, 0.319723, 0.294374, 0.832637]))))
```