### PR TITLE
Make cg work on GPU and throw informative errors when about to segfault

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.7-beta
 
 RecipesBase 0.3.1
+GPUArrays

--- a/src/IterativeSolvers.jl
+++ b/src/IterativeSolvers.jl
@@ -6,6 +6,8 @@ eigensystems, and singular value problems.
 """
 module IterativeSolvers
 
+using GPUArrays
+
 include("common.jl")
 include("orthogonalize.jl")
 include("history.jl")

--- a/src/common.jl
+++ b/src/common.jl
@@ -15,7 +15,6 @@ Adivtype(A, b) = typeof(one(eltype(b))/one(eltype(A)))
 Build a zeros vector `Vector{T}`, where `T` is `Adivtype(A,b)`.
 """
 zerox(A, b) = zeros(Adivtype(A, b), size(A, 2))
-zerox(A, b::GPUArray) = zerox(A::GPUArray, b) = throw("Please pre-allocate the result vector on the GPU and use an inplace function.")
 
 """
 No-op preconditioner

--- a/src/common.jl
+++ b/src/common.jl
@@ -15,6 +15,7 @@ Adivtype(A, b) = typeof(one(eltype(b))/one(eltype(A)))
 Build a zeros vector `Vector{T}`, where `T` is `Adivtype(A,b)`.
 """
 zerox(A, b) = zeros(Adivtype(A, b), size(A, 2))
+zerox(A, b::GPUArray) = zerox(A::GPUArray, b) = throw("Please pre-allocate the result vector on the GPU and use an inplace function.")
 
 """
 No-op preconditioner


### PR DESCRIPTION
So turns out `IterativeSolvers.cg` mostly works on the GPU, but needed a few corner cases handled to make it more friendly. This PR hopefully does this. With this PR, this works:
```julia
using LinearAlgebra, CuArrays, IterativeSolvers

n = 100
A = CuArray(rand(n, n)); A = A + A' + 2*n*I
b = CuArray(rand(n))
x = cg(A, b)
```

`IterativeSolvers.cg!` already worked without this PR when all of `x`, `A` and `b` are on the GPU. If one of them is not, Julia segfaults. I did the check for `x` and `b` to give a friendly error, however since `A` can be a linear operator, I left it unchecked. Feedback appreciated!