### PR TITLE
Minimal changes to make LOBPCG work on the GPU

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.7-beta
 
 RecipesBase 0.3.1
+GPUArrays

--- a/src/IterativeSolvers.jl
+++ b/src/IterativeSolvers.jl
@@ -6,6 +6,8 @@ eigensystems, and singular value problems.
 """
 module IterativeSolvers
 
+using GPUArrays
+
 include("common.jl")
 include("orthogonalize.jl")
 include("history.jl")

--- a/src/common.jl
+++ b/src/common.jl
@@ -15,7 +15,6 @@ Adivtype(A, b) = typeof(one(eltype(b))/one(eltype(A)))
 Build a zeros vector `Vector{T}`, where `T` is `Adivtype(A,b)`.
 """
 zerox(A, b) = zeros(Adivtype(A, b), size(A, 2))
-zerox(A, b::GPUArray) = zerox(A::GPUArray, b) = throw("Please pre-allocate the result vector on the GPU and use an inplace function.")
 
 """
 No-op preconditioner

--- a/src/common.jl
+++ b/src/common.jl
@@ -15,6 +15,7 @@ Adivtype(A, b) = typeof(one(eltype(b))/one(eltype(A)))
 Build a zeros vector `Vector{T}`, where `T` is `Adivtype(A,b)`.
 """
 zerox(A, b) = zeros(Adivtype(A, b), size(A, 2))
+zerox(A, b::GPUArray) = zerox(A::GPUArray, b) = throw("Please pre-allocate the result vector on the GPU and use an inplace function.")
 
 """
 No-op preconditioner


### PR DESCRIPTION
This PR makes the least amount of changes to make the LOBPCG algorithm work on GPUArrays. With this PR, the following just works:
```julia
using LinearAlgebra, CuArrays, IterativeSolvers

n = 1000;
A = CuArray(rand(n, n)); A = A + A' + 2*n*I;
X = CuArray(rand(n, 2));
iterator = LOBPCGIterator(A, true, X);
result = lobpcg!(iterator, maxiter=n÷2)
#=
Results of LOBPCG Algorithm
 * Algorithm: LOBPCG - CholQR
 * λ: [3000.625943844625,2025.7587087557938]
 * Residual norm(s): [1.0455519186709642e-5,1.9208507426245153e-5]
 * Convergence
   * Iterations: 98
   * Converged: true
   * Iterations limit: 500
=#

typeof(result.X)
#CuArray{Float64,2}
```
Notice that small matrix operations are all done on the CPU on purpose, and there are some unoptimized allocations.

Supporting `DistributedArrays` is also somewhat trivial if one extends the [gmul](https://github.com/mohamed82008/IterativeSolvers.jl/blob/2446745abf1df310bfeb4d0834d6e90a6b7de881/src/lobpcg.jl#L117) functions for `DistributedArrays`, but this will mean that we have to depend on `DistributedArrays`. If there is a lightweight `AbstractDistributedArrays` package, that would be nice to use instead.