### PR TITLE
Fix vector types in cg state

### DIFF
--- a/src/cg.jl
+++ b/src/cg.jl
@@ -116,7 +116,7 @@ end
 function cg_iterator!(x, A, b, Pl = Identity();
     tol = sqrt(eps(real(eltype(b)))),
     maxiter::Int = size(A, 2),
-    statevars::CGStateVariables = CGStateVariables{eltype(x),typeof(x)}(zero(x), similar(x), similar(x)),
+    statevars::CGStateVariables = CGStateVariables{eltype(x),typeof(similar(x))}(zero(x), similar(x), similar(x)),
     initially_zero::Bool = false
 )
     u = statevars.u
@@ -202,7 +202,7 @@ function cg!(x, A, b;
     tol = sqrt(eps(real(eltype(b)))),
     maxiter::Int = size(A, 2),
     log::Bool = false,
-    statevars::CGStateVariables = CGStateVariables{eltype(x), typeof(x)}(zero(x), similar(x), similar(x)),
+    statevars::CGStateVariables = CGStateVariables{eltype(x), typeof(similar(x))}(zero(x), similar(x), similar(x)),
     verbose::Bool = false,
     Pl = Identity(),
     kwargs...


### PR DESCRIPTION
This solves this issue https://github.com/kul-forbes/ProximalOperators.jl/issues/64
When `x` is a `SubArray`, `zero(x)` creates an `Array` and the types will not be the same. `similar(x::SubArray)` also results in an `Array`