### PR TITLE
Fix DiagonalIndices when sparse matrix indices are not Int64.

### DIFF
--- a/src/stationary_sparse.jl
+++ b/src/stationary_sparse.jl
@@ -12,8 +12,8 @@ struct DiagonalIndices{Tv, Ti <: Integer}
         diag = Vector{Ti}(undef, A.n)
 
         for col = 1 : A.n
-            r1 = A.colptr[col]
-            r2 = A.colptr[col + 1] - 1
+            r1 = Int64(A.colptr[col])
+            r2 = Int64(A.colptr[col + 1] - 1)
             r1 = searchsortedfirst(A.rowval, col, r1, r2, Base.Order.Forward)
             if r1 > r2 || A.rowval[r1] != col || iszero(A.nzval[r1])
                 throw(LinearAlgebra.SingularException(col))

--- a/src/stationary_sparse.jl
+++ b/src/stationary_sparse.jl
@@ -12,8 +12,8 @@ struct DiagonalIndices{Tv, Ti <: Integer}
         diag = Vector{Ti}(undef, A.n)
 
         for col = 1 : A.n
-            r1 = Int64(A.colptr[col])
-            r2 = Int64(A.colptr[col + 1] - 1)
+            r1 = Int(A.colptr[col])
+            r2 = Int(A.colptr[col + 1] - 1)
             r1 = searchsortedfirst(A.rowval, col, r1, r2, Base.Order.Forward)
             if r1 > r2 || A.rowval[r1] != col || iszero(A.nzval[r1])
                 throw(LinearAlgebra.SingularException(col))

--- a/test/cg.jl
+++ b/test/cg.jl
@@ -58,7 +58,7 @@ end
     rmul!(rhs, inv(norm(rhs)))
     tol = 1e-5
 
-    @testset "Matrix" begin
+    @testset "SparseMatrixCSC{$T, $Ti}" for T in (Float64, Float32), Ti in (Int64, Int32)
         xCG = cg(A, rhs; tol=tol, maxiter=100)
         xJAC = cg(A, rhs; Pl=P, tol=tol, maxiter=100)
         @test norm(A * xCG - rhs) ≤ tol

--- a/test/gmres.jl
+++ b/test/gmres.jl
@@ -33,7 +33,7 @@ n = 10
     @test norm(A * x - b) / norm(b) ≤ tol
 end
 
-@testset "SparseMatrixCSC{$T}" for T in (Float64, ComplexF64)
+@testset "SparseMatrixCSC{$T, $Ti}" for T in (Float64, ComplexF64), Ti in (Int64, Int32)
     A = sprand(T, n, n, 0.5) + I
     b = rand(T, n)
     F = lu(A)

--- a/test/idrs.jl
+++ b/test/idrs.jl
@@ -29,7 +29,7 @@ Random.seed!(1234567)
     end
 end
 
-@testset "SparseMatrixCSC{$T}" for T in (Float64, ComplexF64)
+@testset "SparseMatrixCSC{$T, $Ti}" for T in (Float64, ComplexF64), Ti in (Int64, Int32)
     A = sprand(T, n, n, 0.5) + n * I
     b = rand(T, n)
     tol = √eps(real(T))

--- a/test/minres.jl
+++ b/test/minres.jl
@@ -51,7 +51,7 @@ end
     @test hist.isconverged
 end
 
-@testset "SparseMatrixCSC{$T}" for T in (Float32, Float64, ComplexF32, ComplexF64)
+@testset "SparseMatrixCSC{$T, $Ti}" for T in (Float32, Float64, ComplexF32, ComplexF64), Ti in (Int64, Int32)
     A = let
         B = sprand(n, n, 2 / n)
         B + B' + I

--- a/test/stationary.jl
+++ b/test/stationary.jl
@@ -16,7 +16,7 @@ m = 6
 ω = 1.2
 Random.seed!(1234322)
 
-@testset "SparseMatrix{$T}" for T in (Float32, Float64, ComplexF32, ComplexF64)
+@testset "SparseMatrix{$T, $Ti}" for T in (Float32, Float64, ComplexF32, ComplexF64), Ti in (Int64, Int32)
     @testset "Sparse? $sparse" for sparse = (true, false)
         # Diagonally dominant
         if sparse


### PR DESCRIPTION
`searchsortedfirst` (used to get diagonal entries) requires its inputs to be Int64. When the sparse matrix passed to DiagonalIndices has a different type of indices, `searchsortedfirst` is not found. I've fixed this issue and added tests to cover this behavior.