### PR TITLE
QMR

### DIFF
--- a/src/IterativeSolvers.jl
+++ b/src/IterativeSolvers.jl
@@ -22,6 +22,7 @@ include("bicgstabl.jl")
 include("gmres.jl")
 include("chebyshev.jl")
 include("idrs.jl")
+include("qmr.jl")
 
 # Eigensolvers
 include("simple.jl")

--- a/src/history.jl
+++ b/src/history.jl
@@ -205,7 +205,7 @@ end
 """
     nextiter!(ml)
 
-Adds one the the number of iterations in [`ConvergenceHistory`](@ref) `ch`. This is
+Adds one to the number of iterations in [`ConvergenceHistory`](@ref) `ch`. This is
 necessary to avoid overwriting information with `push!(ml)`. It is also able
 to update other information of the method.
 """

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -12,7 +12,7 @@ qmr(A, b; kwargs...) = qmr!(zerox(A, b), A, b; initially_zero = true, kwargs...)
 """
     qmr!(x, A, b; kwargs...) -> x, [history]
 
-Solves the problem ``Ax = b`` with the Quasi-Minimal Residual method.
+Solves the problem ``Ax = b`` with the Quasi-Minimal Residual method without lookahead.
 
 # Arguments
 
@@ -44,13 +44,108 @@ Solves the problem ``Ax = b`` with the Quasi-Minimal Residual method.
 - `history`: convergence history.
 """
 function qmr!(x,A, b;
-  Pl = Identity(),
-  Pr = Identity(),
+  Pl = I,
+  Pr = I,
   tol = sqrt(eps(real(eltype(b)))),
   maxiter = size(A, 2),
   log::Bool = false,
   initially_zero::Bool = false,
   verbose::Bool = false)
 
+  history = ConvergenceHistory(partial = !log)
+  history[:tol] = tol
+  reserve!(history, :resnorm, maxiter)
 
+  δ = []
+  p = []
+  q = []
+  ϵ = []
+  β = []
+  θ = []
+
+  r = b-A*x
+  ν_vec = [zeros((length(r),1)),r]
+  y = Pl \ ν_vec[2]
+  ρ = [0,norm(y,2)]
+  w_vec = [zeros((length(r),1)),r]
+  z =  Pr' \ w_vec[2]
+  ζ = [0,norm(z,2)]
+
+  γ = [1]
+  η = [-1]
+
+  for i in 2:maxiter
+
+    if ρ[i] == 0 || ζ[1] == 0
+      history.isconverged = false;
+      break
+    end
+
+    ν[i] = ν_vec[i]/ρ[i];y = y / ρ[i]
+    w[i] = w_vec[i]/ζ[i];z = z / ζ[i]
+    δ[i] = z'*y
+
+    if δ[i] == 0
+      history.isconverged = false;
+      break
+    end
+
+    y_vec = Pr \ y
+    z_vec = Pl' \ z
+
+    if i == 2
+      p[2] = y_vec; q[2] = z_vec
+    else
+      p[i] = y_vec - ((ζ[i]*δ[i])/(ϵ[i-1]))*p[i-1]
+      q[i] = z_vec - ((ρ[i]*δ[i])/(ϵ[i-1]))*q[i-1]
+    end
+
+    p_vec = A*p[i]
+    ϵ[i] = q[i]'*p_vec
+
+    if ϵ[i] == 0
+      history.isconverged = false;
+      break;
+    end
+
+    β[i] = ϵ[i] / δ[i]
+
+    if β[i] == 0
+      history.isconverged = false;
+      break;
+    end
+
+    ν_vec[i+1] = p_vec - β[i]*ν[i]
+    y = ν_vec[i+1] \ Pl
+    ρ[i+1] = norm(y,2)
+    w_vec[i+1] = A'*q[i] - β[i]*w[i]
+    z = w_vec[i+1] \ Pr'
+    ζ[i+1] = norm(z,2)
+    θ[i] = ρ[i+1] / (γ[i-1] * abs(β[i]))
+    γ[i] = 1 / sqrt(1 + θ[i]^2)
+
+    if γ[i] == 0
+      history.isconverged = false;
+      break;
+    end
+
+    η[i] = (-η[i-1]*ρ[i]*γ[i]^2)/(β[i]*γ[i-1]^2)
+
+    if i == 2
+      d[2] = η[2]*p[2]; s[2] = η[2]*p_vec
+    else
+      d[i] = η[i]*p[i] + (θ[i-1]*γ[i])^2*d[i-1]
+      s[i] = η[i]*p_vec + (θ[i-1]*γ[i])^2*s[i-1]
+    end
+
+    x[i] = x[i-1] + d[i]
+    r[i] = r[i-1] - s[i]
+    push!(history, :resnorm, r[i])
+    if r[i] <= tol
+      history.isconverged = true;
+      break;
+    end
+  end
+
+  log ? (x,history) :  x
 end

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -73,8 +73,6 @@ function qmr!(x, A, b;
   r = b - A*x
   bnorm = norm(b)
   res₀ = norm(r)
-  res_vec = zeros(btype,maxiter+1)
-  res_vec[1] = res₀
   vt = r
   y = Pr \ vt
   ρ₀ = norm(y)
@@ -99,7 +97,6 @@ function qmr!(x, A, b;
   d = zeros(btype,length(b))
   s = zeros(btype,length(b))
   res₁ = zero(btype)
-  last_iter = zero(Int64)
 
   for iter = 1:maxiter
     ## If ρ₀ == 0 or xi1 == 0, method fails.
@@ -141,7 +138,6 @@ function qmr!(x, A, b;
     r -= s
 
     res₁ = norm(r) / bnorm
-    res_vec[iter+1] = norm(r)
 
     # Check for convergance
     if (res₁ < tol)
@@ -149,14 +145,12 @@ function qmr!(x, A, b;
       if log
         history.isconverged = true
       end
-      last_iter = iter
       break
     elseif (res₀ <= res₁)
       # Local minimum found
       if log
         history.isconverged = true
       end
-      last_iter = iter
       break
     end
     θ₀ = θ₁
@@ -164,12 +158,11 @@ function qmr!(x, A, b;
     γ₀ = γ₁
     ρ₀ = ρ₁
     nextiter!(history)
-    log && push!(history,:resnorm,norm(r))
+    log && push!(history,:resnorm,res₁)
   end
 
   verbose && println()
   log && shrink!(history)
 
-  relres = res₁
   log ? (x, history) :  x
 end

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -1,0 +1,3 @@
+export qmr, qmr!
+
+using LinearAlgebra

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -1,3 +1,65 @@
 export qmr, qmr!
 
 using LinearAlgebra
+
+"""
+    qmr(A, b; kwargs...) -> x, [history]
+
+Same as [`qmr!`](@ref), but allocates a solution vector `x` initialized with zeros.
+"""
+qmr(A, b; kwargs...) = qmr!(zerox(A, b), A, b; initially_zero = true, kwargs...)
+
+"""
+    qmr!(x, A, b; kwargs...) -> x, [history]
+
+Solves the problem ``Ax = b`` with the Quasi-Minimal Residual method.
+
+# Arguments
+
+- `A`: linear operator;
+- `b`: right-hand side.
+- `x`: Initial guess, will be updated in-place;
+
+## Keywords
+
+- `initially_zero::Bool`: If `true` assumes that `iszero(x)` so that one
+  matrix-vector product can be saved when computing the initial
+  residual vector;
+- `tol`: relative tolerance;
+- `Pl`: left preconditioner;
+- `Pr`: right preconditioner;
+- `maxiter::Int = size(A, 2)`: Maximum number of iterations
+- `log::Bool`: keep track of the residual norm in each iteration;
+- `verbose::Bool`: print convergence information during the iterations.
+
+# Return values
+
+**if `log` is `false`**
+
+- `x`: approximate solution.
+
+**if `log` is `true`**
+
+- `x`: approximate solution;
+- `history`: convergence history.
+"""
+
+#########################
+# Method Implementation #
+#########################
+
+# Kiran Shila and Eric Valentino
+# Dept of Electrical Engineering
+# University of South Florida
+#-----------------------------
+function qmr!(x,A, b;
+  Pl = Identity(),
+  Pr = Identity(),
+  tol = sqrt(eps(real(eltype(b)))),
+  maxiter = size(A, 2),
+  log::Bool = false,
+  initially_zero::Bool = false,
+  verbose::Bool = false)
+
+
+end

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -16,15 +16,9 @@ Solves the problem ``Ax = b`` with the Quasi-Minimal Residual method.
 
 # Arguments
 
-<<<<<<< HEAD
 - `A`: linear operator;
 - `b`: right-hand side.
 - `x`: Initial guess, will be updated in-place;
-=======
-- `x`: Initial guess, will be updated in-place;
-- `A`: linear operator;
-- `b`: right-hand side.
->>>>>>> 8c9ae8a8aee84bfa4974c21cfb134c11ab265870
 
 ## Keywords
 
@@ -34,10 +28,7 @@ Solves the problem ``Ax = b`` with the Quasi-Minimal Residual method.
 - `tol`: relative tolerance;
 - `Pl`: left preconditioner;
 - `Pr`: right preconditioner;
-<<<<<<< HEAD
 - `maxiter::Int = size(A, 2)`: Maximum number of iterations
-=======
->>>>>>> 8c9ae8a8aee84bfa4974c21cfb134c11ab265870
 - `log::Bool`: keep track of the residual norm in each iteration;
 - `verbose::Bool`: print convergence information during the iterations.
 
@@ -52,27 +43,11 @@ Solves the problem ``Ax = b`` with the Quasi-Minimal Residual method.
 - `x`: approximate solution;
 - `history`: convergence history.
 """
-<<<<<<< HEAD
-
-#########################
-# Method Implementation #
-#########################
-
-# Kiran Shila and Eric Valentino
-# Dept of Electrical Engineering
-# University of South Florida
-#-----------------------------
 function qmr!(x,A, b;
   Pl = Identity(),
   Pr = Identity(),
   tol = sqrt(eps(real(eltype(b)))),
   maxiter = size(A, 2),
-=======
-function qmr!(x, A, b;
-  Pl = Identity(),
-  Pr = Identity(),
-  tol = sqrt(eps(real(eltype(b)))),
->>>>>>> 8c9ae8a8aee84bfa4974c21cfb134c11ab265870
   log::Bool = false,
   initially_zero::Bool = false,
   verbose::Bool = false)

--- a/test/qmr.jl
+++ b/test/qmr.jl
@@ -1,0 +1,5 @@
+using IterativeSolvers
+using Test
+using LinearAlgebra
+using SparseArrays
+using Random

--- a/test/qmr.jl
+++ b/test/qmr.jl
@@ -12,7 +12,7 @@ function matlab_example(T,n)
     M1 = spdiagm(-1 => fill(-1/2,n-1), 0 => ones(n))
     M2 = spdiagm(0 => fill(4,n), 1 => fill(-1,n-1))
     x = ones(T,100)
-    A,x,b
+    A,x,b,M1,M2
 end
 
 Random.seed!(123)
@@ -23,8 +23,8 @@ Random.seed!(123)
 
     x0 = rand(T,n)
 
-    x1, hist1 = qmr(A, b, maxiter = 15, tol = tol, log = true)
-    x2, hist2 = qmr!(x0, A, b, maxiter = 15, tol = tol, log = true)
+    x1, hist1 = qmr(A, b, maxiter = 15, tol = tol, log = true,Pl=M1,Pr=M2)
+    x2, hist2 = qmr!(x0, A, b, maxiter = 15, tol = tol, log = true,Pl=M1,Pr=M2)
 
     @test isa(hist1, ConvergenceHistory)
     @test norm(b - A * x1) / norm(b) ≤ tol

--- a/test/qmr.jl
+++ b/test/qmr.jl
@@ -32,3 +32,5 @@ Random.seed!(123)
     @test norm(b - A * x2) / norm(b) ≤ tol
     @test x2 == x0
 end
+
+end

--- a/test/qmr.jl
+++ b/test/qmr.jl
@@ -3,3 +3,32 @@ using Test
 using LinearAlgebra
 using SparseArrays
 using Random
+
+@testset "QMR" begin
+
+function matlab_example(T,n)
+    A = spdiagm(-1 => fill(-1,n-1), 1 => fill(4,n-1))
+    b = sum(A,dims=2)
+    M1 = spdiagm(-1 => fill(-1/2,n-1), 0 => ones(n))
+    M2 = spdiagm(0 => fill(4,n), 1 => fill(-1,n-1))
+    x = ones(T,100)
+    A,x,b
+end
+
+Random.seed!(123)
+
+@testset "MATLAB Example Matrix{$T}" for T in (Float32, Float64, ComplexF32, ComplexF64)
+    A, x, b = matlab_example(T, n)
+    tol = 1e-8
+
+    x0 = rand(T,n)
+
+    x1, hist1 = qmr(A, b, maxiter = 15, tol = tol, log = true)
+    x2, hist2 = qmr!(x0, A, b, maxiter = 15, tol = tol, log = true)
+
+    @test isa(hist1, ConvergenceHistory)
+    @test norm(b - A * x1) / norm(b) ≤ tol
+    @test hist1.isconverged
+    @test norm(b - A * x2) / norm(b) ≤ tol
+    @test x2 == x0
+end

--- a/test/qmr.jl
+++ b/test/qmr.jl
@@ -6,6 +6,35 @@ using Random
 
 @testset "QMR" begin
 
+    function matlab_example(T,n)
+        A = spdiagm(-1 => fill(-1,n-1), 1 => fill(4,n-1))
+        b = sum(A,dims=2)
+        M1 = spdiagm(-1 => fill(-1/2,n-1), 0 => ones(n))
+        M2 = spdiagm(0 => fill(4,n), 1 => fill(-1,n-1))
+        x = ones(T,100)
+        A,x,b,M1,M2
+    end
+
+    Random.seed!(123)
+
+    @testset "MATLAB Example Matrix{$T}" for T in (Float32, Float64, ComplexF32, ComplexF64)
+        A, x, b, M1, M2 = matlab_example(T, 100)
+        tol = 1e-8
+
+        x0 = rand(T,100)
+
+        x1, hist1 = qmr(A, b, maxiter = 15, tol = tol, log = true,Pl=M1,Pr=M2)
+        x2, hist2 = qmr!(x0, A, b, maxiter = 15, tol = tol, log = true,Pl=M1,Pr=M2)
+
+        @test isa(hist1, ConvergenceHistory)
+        @test norm(b - A * x1) / norm(b) ≤ tol
+        @test hist1.isconverged
+        @test norm(b - A * x2) / norm(b) ≤ tol
+        @test x2 == x0
+    end
+
+end
+
 function matlab_example(T,n)
     A = spdiagm(-1 => fill(-1,n-1), 1 => fill(4,n-1))
     b = sum(A,dims=2)
@@ -15,22 +44,7 @@ function matlab_example(T,n)
     A,x,b,M1,M2
 end
 
-Random.seed!(123)
+A, x, b, M1, M2 = matlab_example(Float64, 100)
 
-@testset "MATLAB Example Matrix{$T}" for T in (Float32, Float64, ComplexF32, ComplexF64)
-    A, x, b = matlab_example(T, n)
-    tol = 1e-8
-
-    x0 = rand(T,n)
-
-    x1, hist1 = qmr(A, b, maxiter = 15, tol = tol, log = true,Pl=M1,Pr=M2)
-    x2, hist2 = qmr!(x0, A, b, maxiter = 15, tol = tol, log = true,Pl=M1,Pr=M2)
-
-    @test isa(hist1, ConvergenceHistory)
-    @test norm(b - A * x1) / norm(b) ≤ tol
-    @test hist1.isconverged
-    @test norm(b - A * x2) / norm(b) ≤ tol
-    @test x2 == x0
-end
-
-end
+x, history = qmr!(x, A, b, maxiter = 15, tol = 1e-6, log = true,Pl=M1,Pr=M2)
+A\b


### PR DESCRIPTION
This is a quick implementation of the non-lookahead QMR method. It is a work in progress and right now seems to be pretty memory hungry.

I added some simple test code and it currently does pass all tests.

I am looking for some help to bring down the memory load and to make sure it is consistent with the other IterativeSolvers.jl methods