### PR TITLE
CG's stopping criteria

### DIFF
--- a/src/cg.jl
+++ b/src/cg.jl
@@ -128,7 +128,7 @@ function cg_iterator!(x, A, b, Pl = Identity();
     # Compute r with an MV-product or not.
     if initially_zero
         mv_products = 0
-        c = zero(x)
+        c .= zero(eltype(c))
         residual = norm(b)
         reltol = residual * tol # Save one dot product
     else

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -116,7 +116,7 @@ end
 function cg_iterator!(x, A, b, Pl = Identity();
     tol = sqrt(eps(real(eltype(b)))),
     maxiter::Int = size(A, 2),
-    statevars::CGStateVariables = CGStateVariables(zero(x), similar(x), similar(x)),
+    statevars::CGStateVariables = CGStateVariables(zero(x), zero(x), zero(x)),
     initially_zero::Bool = false
 )
     u = statevars.u
@@ -128,7 +128,7 @@ function cg_iterator!(x, A, b, Pl = Identity();
     # Compute r with an MV-product or not.
     if initially_zero
         mv_products = 0
-        c = similar(x)
+        c = zero(x)
         residual = norm(b)
         reltol = residual * tol # Save one dot product
     else
@@ -136,7 +136,7 @@ function cg_iterator!(x, A, b, Pl = Identity();
         mul!(c, A, x)
         r .-= c
         residual = norm(r)
-        reltol = norm(b) * tol
+        reltol = norm(r) * tol
     end
 
     # Return the iterable
@@ -202,7 +202,7 @@ function cg!(x, A, b;
     tol = sqrt(eps(real(eltype(b)))),
     maxiter::Int = size(A, 2),
     log::Bool = false,
-    statevars::CGStateVariables = CGStateVariables(zero(x), similar(x), similar(x)),
+    statevars::CGStateVariables = CGStateVariables(zero(x), zero(x), zero(x)),
     verbose::Bool = false,
     Pl = Identity(),
     kwargs...


### PR DESCRIPTION
# The problem
CG does not respect the stopping criterion of the documentation: 

> |r_k| / |r_0| ≤ tol

as it can be observed from the following minimal example:
```
using IterativeSolvers

n = 3
A = Matrix(I, n, n)
b = randn(n)

x = b + 1e-5*randn(n) # Initialize x close to the solution b
tol = 1e-3
initial_residual = norm(A*x - b)

output, history = cg!(x, A, b, tol=tol, initially_zero=false, log=true, verbose=true)
@assert norm(A*x - b)/initial_residual <= tol
```

It appears that `cg` stops when `|r_k| / |b| ≤ tol`. However, I am unsure if this actually holds, as the `CGStateVariables` are filled with vectors generated with the `similar()` command which can be problematic, as it does not initialise the memory of the vectors.

# Suggested solution

Change the stopping criterion to match the one of the documentation and replace `similar()` with `zero()`.

I suppose that another possibility would be to change the documentation? Let me know what you think!