### PR TITLE
Fix 246 - LOBPCG hack for CholQR

### DIFF
--- a/src/lobpcg.jl
+++ b/src/lobpcg.jl
@@ -337,6 +337,8 @@ function (g::BlockGram)(gram, n1::Int, n2::Int, n3::Int, normalized::Bool=true)
     return
 end
 
+# Any orthogonalization algorithm should guarantee that X' B X is the identity
+# A * X and B * X should be updated accordingly
 abstract type AbstractOrtho end
 
 struct CholQROrtho{TA} <: AbstractOrtho

--- a/src/lobpcg.jl
+++ b/src/lobpcg.jl
@@ -338,7 +338,8 @@ function (g::BlockGram)(gram, n1::Int, n2::Int, n3::Int, normalized::Bool=true)
 end
 
 abstract type AbstractOrtho end
-struct CholQR{TA} <: AbstractOrtho
+
+struct CholQROrtho{TA} <: AbstractOrtho
     gramVBV::TA # to be used in view
 end
 
@@ -362,7 +363,7 @@ function realdiag!(M::AbstractMatrix{TC}) where TC <: Complex
     return M
 end
 
-function (ortho!::CholQR)(XBlocks::Blocks{Generalized}, sizeX = -1; update_AX=false, update_BX=false) where Generalized
+function (ortho!::CholQROrtho)(XBlocks::Blocks{Generalized}, sizeX = -1; update_AX=false, update_BX=false) where Generalized
     useview = sizeX != -1
     if sizeX == -1
         sizeX = size(XBlocks.block, 2)
@@ -478,7 +479,7 @@ function LOBPCGIterator(A, B, largest::Bool, X, precond!::RPreconditioner, const
     iteration = Ref(1)
     currentBlockSize = Ref(nev)
     generalized = !(B isa Nothing)
-    ortho! = CholQR(zeros(T, nev, nev))
+    ortho! = CholQROrtho(zeros(T, nev, nev))
 
     gramABlock = BlockGram(XBlocks)
     gramBBlock = BlockGram(XBlocks)

--- a/src/lobpcg.jl
+++ b/src/lobpcg.jl
@@ -373,6 +373,7 @@ function (ortho!::CholQROrtho)(XBlocks::Blocks{Generalized}, sizeX = -1; update_
     X = XBlocks.block
     BX = XBlocks.B_block # Assumes it is premultiplied
     AX = XBlocks.A_block
+    T = eltype(X)
     @views gram_view = ortho!.gramVBV[1:sizeX, 1:sizeX]
     @views if useview
         mul!(gram_view, adjoint(X[:, 1:sizeX]), BX[:, 1:sizeX])
@@ -380,7 +381,7 @@ function (ortho!::CholQROrtho)(XBlocks::Blocks{Generalized}, sizeX = -1; update_
         mul!(gram_view, adjoint(X), BX)
     end
     realdiag!(gram_view)
-    cholf = cholesky!(Hermitian(gram_view))
+    cholf = cholesky!(Hermitian(gram_view + eps(T)*I))
     R = cholf.factors
     @views if useview
         rdiv!(X[:, 1:sizeX], UpperTriangular(R))


### PR DESCRIPTION
Works around #246 by offsetting the gram matrix before taking Cholesky.

CC: @mfherbst, @haampie, @lobpcg