### PR TITLE
adding type to reserve! in most solvers

### DIFF
--- a/src/bicgstabl.jl
+++ b/src/bicgstabl.jl
@@ -185,7 +185,7 @@ function bicgstabl!(x, A, b, l = 2;
     history[:tol] = tol
 
     # This doesn't yet make sense: the number of iters is smaller.
-    log && reserve!(history, :resnorm, max_mv_products)
+    log && reserve!(typeof(tol), history, :resnorm, max_mv_products)
 
     # Actually perform CG
     iterable = bicgstabl_iterator!(x, A, b, l; Pl = Pl, tol = tol, max_mv_products = max_mv_products, kwargs...)

--- a/src/cg.jl
+++ b/src/cg.jl
@@ -209,7 +209,7 @@ function cg!(x, A, b;
 )
     history = ConvergenceHistory(partial = !log)
     history[:tol] = tol
-    log && reserve!(history, :resnorm, maxiter + 1)
+    log && reserve!(typeof(tol), history, :resnorm, maxiter + 1)
 
     # Actually perform CG
     iterable = cg_iterator!(x, A, b, Pl; tol = tol, maxiter = maxiter, statevars = statevars, kwargs...)

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -139,7 +139,7 @@ function chebyshev!(x, A, b, λmin::Real, λmax::Real;
 )
     history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
-    reserve!(history, :resnorm, maxiter)
+    reserve!(typeof(tol), history, :resnorm, maxiter)
 
     verbose && @printf("=== chebyshev ===\n%4s\t%7s\n","iter","resnorm")
 

--- a/src/gmres.jl
+++ b/src/gmres.jl
@@ -181,7 +181,7 @@ function gmres!(x, A, b;
 )
     history = ConvergenceHistory(partial = !log, restart = restart)
     history[:tol] = tol
-    log && reserve!(history, :resnorm, maxiter)
+    log && reserve!(typeof(tol), history, :resnorm, maxiter)
 
     iterable = gmres_iterable!(x, A, b; Pl = Pl, Pr = Pr, tol = tol, maxiter = maxiter, restart = restart, initially_zero = initially_zero)
 

--- a/src/idrs.jl
+++ b/src/idrs.jl
@@ -46,7 +46,7 @@ function idrs!(x, A, b;
     )
     history = ConvergenceHistory(partial=!log)
     history[:tol] = tol
-    reserve!(history,:resnorm, maxiter)
+    reserve!(typeof(tol), history,:resnorm, maxiter)
     idrs_method!(history, x, A, b, s, tol, maxiter; kwargs...)
     log && shrink!(history)
     log ? (x, history) : x

--- a/src/minres.jl
+++ b/src/minres.jl
@@ -200,7 +200,7 @@ function minres!(x, A, b;
 )
     history = ConvergenceHistory(partial = !log)
     history[:tol] = tol
-    log && reserve!(history, :resnorm, maxiter)
+    log && reserve!(typeof(tol), history, :resnorm, maxiter)
 
     iterable = minres_iterable!(x, A, b;
         skew_hermitian = skew_hermitian,

--- a/src/qmr.jl
+++ b/src/qmr.jl
@@ -262,7 +262,7 @@ function qmr!(x, A, b;
 )
     history = ConvergenceHistory(partial = !log)
     history[:tol] = tol
-    log && reserve!(history, :resnorm, maxiter)
+    log && reserve!(typeof(tol), history, :resnorm, maxiter)
 
     iterable = qmr_iterable!(x, A, b; tol = tol, maxiter = maxiter, initially_zero = initially_zero)
 

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -126,7 +126,7 @@ function powm!(B, x;
 )
     history = ConvergenceHistory(partial = !log)
     history[:tol] = tol
-    reserve!(history, :resnorm, maxiter)
+    reserve!(typeof(tol), history, :resnorm, maxiter)
     verbose && @printf("=== powm ===\n%4s\t%7s\n", "iter", "resnorm")
 
     iterable = powm_iterable!(B, x, tol = tol, maxiter = maxiter)


### PR DESCRIPTION
When storing a log, solvers reserve memory with `reserve!`. By default no type information is passed to this method which, then, converts the history into Float64.
This is not the expected behaviour when using non traditional types (for instrumentation purpose) and can lead to problems if their silent convertion into Float64 is not detected by the programmer.

Thus I replaced several occurences of `reserve!(history, ...` with `reserve!(typeof(tol), history, ...`.

I did not modify `lsqr.jl`, `lsmr.jl` and `svdl.jl` as the modification was less straightforward but they should probably be modified in the same way.

(overall I think that `reserve!` should always stipulate the expected type to avoid regression on this issue)