### PR TITLE
This comma does not belong here.

### DIFF
--- a/src/idrs.jl
+++ b/src/idrs.jl
@@ -103,7 +103,7 @@ function idrs_method!(log::ConvergenceHistory, X, A, C::T,
 
     om::eltype(C) = 1
     while normR > tol && iter ≤ maxiter
-        for i in 1:s,
+        for i in 1:s
             f[i] = dot(P[i], R)
         end
         for k in 1:s


### PR DESCRIPTION
It's not exactly clear to me how this did run all those years and apparently worked fine.

Edit: Apparently it worked as a nested loop, iterating over the result of the dot product and using `f[i]` as iteration variable and working this way.