### PR TITLE
add GitHub actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main and dev branches branch
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
+
+jobs:
+  test:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1'
+          - '1.5'
+          # - 'nightly'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ./lcov.info
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: julia-actions/julia-uploadcoveralls@v1
+        env:
+          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
-      - uses: julia-actions/julia-uploadcoveralls@v1
-        env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+      - uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: run-${{ matrix.version }}-${{ matrix.os }}-${{ matrix.arch }}
+          parallel: true
+          path-to-lcov: ./lcov.info

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Iterative Solvers
 
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000)](https://github.com/JuliaMath/IterativeSolvers.jl/blob/master/LICENSE)
+[![Build Status](https://github.com/JuliaMath/IterativeSolvers.jl/workflows/CI/badge.svg)](https://github.com/JuliaMath/IterativeSolvers.jl/actions)
 [![Build Status on Linux](https://travis-ci.org/JuliaMath/IterativeSolvers.jl.svg?branch=master)](https://travis-ci.org/JuliaMath/IterativeSolvers.jl)
-[![Coverage Status](https://coveralls.io/repos/JuliaMath/IterativeSolvers.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaMath/IterativeSolvers.jl?branch=master)
+[![Codecov](http://codecov.io/github/JuliaMath/IterativeSolvers.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaMath/IterativeSolvers.jl?branch=master)
+[![Coveralls](https://coveralls.io/repos/JuliaMath/IterativeSolvers.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaMath/IterativeSolvers.jl?branch=master)
 
 `IterativeSolvers` is a [Julia](http://julialang.org) package that provides iterative algorithms for solving linear systems, eigensystems, and singular value problems.
 

--- a/test/bicgstabl.jl
+++ b/test/bicgstabl.jl
@@ -28,9 +28,9 @@ n = 20
         @test x2 == x_guess
         @test norm(A * x2 - b) / norm(b) ≤ tol
 
-        # The following tests fails CI on Windows due to a
+        # The following tests fails CI on Windows and Ubuntu due to a
         # `SingularException(4)`
-        if T == Float32 && Sys.iswindows()
+        if T == Float32 && (Sys.iswindows() || Sys.islinux())
             continue
         end
         # Do an exact LU decomp of a nearby matrix

--- a/test/bicgstabl.jl
+++ b/test/bicgstabl.jl
@@ -28,6 +28,11 @@ n = 20
         @test x2 == x_guess
         @test norm(A * x2 - b) / norm(b) ≤ tol
 
+        # The following tests fails CI on Windows due to a
+        # `SingularException(4)`
+        if T == Float32 && Sys.iswindows()
+            continue
+        end
         # Do an exact LU decomp of a nearby matrix
         F = lu(A + rand(T, n, n))
         x3, his3 = bicgstabl(A, b, Pl = F, l, max_mv_products = 100, log = true, tol = tol)


### PR DESCRIPTION
This enables CI tests via GitHub actions since Travis CI will become annoying to use as discussed on Discourse (https://discourse.julialang.org/t/travis-ci-changes-pricing-plans/49528/14).